### PR TITLE
CCALC-3714 (part 1)

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/BothStatutoryPayController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/BothStatutoryPayController.scala
@@ -27,30 +27,34 @@ import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.BooleanForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.BothStatutoryPayId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.{TaxYearInfo, UserAnswers}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.bothStatutoryPay
 
 import scala.concurrent.Future
 
 class BothStatutoryPayController @Inject()(appConfig: FrontendAppConfig,
-                                         override val messagesApi: MessagesApi,
-                                         dataCacheConnector: DataCacheConnector,
-                                         navigator: Navigator,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction) extends FrontendController with I18nSupport {
+                                           override val messagesApi: MessagesApi,
+                                           dataCacheConnector: DataCacheConnector,
+                                           navigator: Navigator,
+                                           getData: DataRetrievalAction,
+                                           requireData: DataRequiredAction,
+                                           taxYearInfo: TaxYearInfo) extends FrontendController with I18nSupport {
+
+  val requiredKey = "bothStatutoryPay.required"
+  val requiredKeyArg = taxYearInfo.previousTaxYearStart
 
   def onPageLoad(mode: Mode) = (getData andThen requireData) {
     implicit request =>
       val preparedForm = request.userAnswers.bothStatutoryPay match {
-        case None => BooleanForm()
-        case Some(value) => BooleanForm().fill(value)
+        case None => BooleanForm(requiredKey, requiredKeyArg)
+        case Some(value) => BooleanForm(requiredKey, requiredKeyArg).fill(value)
       }
       Ok(bothStatutoryPay(appConfig, preparedForm, mode))
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
-      BooleanForm().bindFromRequest().fold(
+      BooleanForm(requiredKey, requiredKeyArg).bindFromRequest().fold(
         (formWithErrors: Form[Boolean]) =>
           Future.successful(BadRequest(bothStatutoryPay(appConfig, formWithErrors, mode))),
         (value) =>

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayBeforeTaxController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayBeforeTaxController.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.childcarecalculatorfrontend.controllers
 import javax.inject.Inject
 
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
+import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.DataCacheConnector
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
@@ -27,6 +28,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayBeforeTaxForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryPayBeforeTaxId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.requests.DataRequest
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayBeforeTax
 
@@ -40,29 +42,42 @@ class PartnerStatutoryPayBeforeTaxController @Inject()(
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction) extends FrontendController with I18nSupport {
 
-  def onPageLoad(mode: Mode) = (getData andThen requireData) {
+  private def sessionExpired(implicit request: RequestHeader): Future[Result] =
+    Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
+
+  private def validateStatutoryPayType[A](block: (String) => Future[Result])
+                                         (implicit request: DataRequest[A]): Future[Result] = {
+
+    request.userAnswers.partnerStatutoryPayType.map {
+      payType => block(Messages(s"statutoryPayTypeLower.$payType"))
+    }.getOrElse(sessionExpired)
+  }
+
+  def onPageLoad(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.partnerStatutoryPayType.getOrElse("")
-
-      val preparedForm = request.userAnswers.partnerStatutoryPayBeforeTax match {
-        case None => PartnerStatutoryPayBeforeTaxForm()
-        case Some(value) => PartnerStatutoryPayBeforeTaxForm().fill(value)
+          val preparedForm = request.userAnswers.partnerStatutoryPayBeforeTax match {
+            case None => PartnerStatutoryPayBeforeTaxForm()
+            case Some(value) => PartnerStatutoryPayBeforeTaxForm().fill(value)
+          }
+          Future.successful(Ok(partnerStatutoryPayBeforeTax(appConfig, preparedForm, mode, statutoryType)))
       }
-      Ok(partnerStatutoryPayBeforeTax(appConfig, preparedForm, mode, statutoryType))
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.partnerStatutoryPayType.getOrElse("")
-
-      PartnerStatutoryPayBeforeTaxForm().bindFromRequest().fold(
-        (formWithErrors: Form[String]) =>
-          Future.successful(BadRequest(partnerStatutoryPayBeforeTax(appConfig, formWithErrors, mode, statutoryType))),
-        (value) =>
-          dataCacheConnector.save[String](request.sessionId, PartnerStatutoryPayBeforeTaxId.toString, value).map(cacheMap =>
-            Redirect(navigator.nextPage(PartnerStatutoryPayBeforeTaxId, mode)(new UserAnswers(cacheMap))))
+          PartnerStatutoryPayBeforeTaxForm().bindFromRequest().fold(
+            (formWithErrors: Form[String]) =>
+              Future.successful(BadRequest(partnerStatutoryPayBeforeTax(appConfig, formWithErrors, mode, statutoryType))),
+            (value) =>
+              dataCacheConnector.save[String](request.sessionId, PartnerStatutoryPayBeforeTaxId.toString, value).map(cacheMap =>
+                Redirect(navigator.nextPage(PartnerStatutoryPayBeforeTaxId, mode)(new UserAnswers(cacheMap))))
       )
+    }
   }
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayController.scala
@@ -27,30 +27,34 @@ import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.BooleanForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryPayId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.{TaxYearInfo, UserAnswers}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPay
 
 import scala.concurrent.Future
 
 class PartnerStatutoryPayController @Inject()(appConfig: FrontendAppConfig,
-                                         override val messagesApi: MessagesApi,
-                                         dataCacheConnector: DataCacheConnector,
-                                         navigator: Navigator,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction) extends FrontendController with I18nSupport {
+                                              override val messagesApi: MessagesApi,
+                                              dataCacheConnector: DataCacheConnector,
+                                              navigator: Navigator,
+                                              getData: DataRetrievalAction,
+                                              requireData: DataRequiredAction,
+                                              taxYearInfo: TaxYearInfo) extends FrontendController with I18nSupport {
+
+  val requiredKey = "partnerStatutoryPay.required"
+  val requiredKeyArg = taxYearInfo.previousTaxYearStart
 
   def onPageLoad(mode: Mode) = (getData andThen requireData) {
     implicit request =>
       val preparedForm = request.userAnswers.partnerStatutoryPay match {
-        case None => BooleanForm()
-        case Some(value) => BooleanForm().fill(value)
+        case None => BooleanForm(requiredKey, requiredKeyArg)
+        case Some(value) => BooleanForm(requiredKey, requiredKeyArg).fill(value)
       }
       Ok(partnerStatutoryPay(appConfig, preparedForm, mode))
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
-      BooleanForm().bindFromRequest().fold(
+      BooleanForm(requiredKey, requiredKeyArg).bindFromRequest().fold(
         (formWithErrors: Form[Boolean]) =>
           Future.successful(BadRequest(partnerStatutoryPay(appConfig, formWithErrors, mode))),
         (value) =>

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayTypeController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayTypeController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayTypeForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryPayTypeId
-import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{Mode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayType
 
@@ -52,10 +52,10 @@ class PartnerStatutoryPayTypeController @Inject()(
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
       PartnerStatutoryPayTypeForm().bindFromRequest().fold(
-        (formWithErrors: Form[String]) =>
+        (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(partnerStatutoryPayType(appConfig, formWithErrors, mode))),
         (value) =>
-          dataCacheConnector.save[String](request.sessionId, PartnerStatutoryPayTypeId.toString, value).map(cacheMap =>
+          dataCacheConnector.save[StatutoryPayTypeEnum.Value](request.sessionId, PartnerStatutoryPayTypeId.toString, value).map(cacheMap =>
             Redirect(navigator.nextPage(PartnerStatutoryPayTypeId, mode)(new UserAnswers(cacheMap))))
       )
   }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryStartDateController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryStartDateController.scala
@@ -20,14 +20,15 @@ import javax.inject.Inject
 
 import org.joda.time.LocalDate
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Result, RequestHeader}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
+import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.DataCacheConnector
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryStartDateForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryStartDateId
+import uk.gov.hmrc.childcarecalculatorfrontend.models.requests.DataRequest
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryStartDate
@@ -43,36 +44,44 @@ class PartnerStatutoryStartDateController @Inject()(
                                         requireData: DataRequiredAction
                                       ) extends FrontendController with I18nSupport {
 
+
   private def sessionExpired(implicit request: RequestHeader): Future[Result] =
     Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
 
-  def onPageLoad(mode: Mode) = (getData andThen requireData) {
+  private def validateStatutoryPayType[A](block: (String) => Future[Result])
+                                         (implicit request: DataRequest[A]): Future[Result] = {
+
+    request.userAnswers.partnerStatutoryPayType.map {
+      payType => block(Messages(s"statutoryPayTypeLower.$payType"))
+    }.getOrElse(sessionExpired)
+  }
+
+  def onPageLoad(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
-      val preparedForm = request.userAnswers.partnerStatutoryStartDate match {
-        case None => PartnerStatutoryStartDateForm()
-        case Some(value) => PartnerStatutoryStartDateForm().fill(value)
+      validateStatutoryPayType {
+        statutoryPay =>
+          val preparedForm = request.userAnswers.partnerStatutoryStartDate match {
+            case None => PartnerStatutoryStartDateForm()
+            case Some(value) => PartnerStatutoryStartDateForm().fill(value)
+          }
+
+          Future.successful(Ok(partnerStatutoryStartDate(appConfig, preparedForm, mode, statutoryPay)))
       }
-
-      request.userAnswers.partnerStatutoryPayType match {
-        case Some(x) => Ok(partnerStatutoryStartDate(appConfig, preparedForm, mode, x))
-        case _ => Redirect(routes.SessionExpiredController.onPageLoad())
-      }
-
-
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.partnerStatutoryPayType.getOrElse("")
-
-      PartnerStatutoryStartDateForm().bindFromRequest().fold(
-        (formWithErrors: Form[LocalDate]) =>
-          Future.successful(BadRequest(partnerStatutoryStartDate(appConfig, formWithErrors, mode, statutoryType))),
-        (value) =>
-          dataCacheConnector.save[LocalDate](request.sessionId, PartnerStatutoryStartDateId.toString, value).map(cacheMap =>
-            Redirect(navigator.nextPage(PartnerStatutoryStartDateId, mode)(new UserAnswers(cacheMap))))
-      )
+          PartnerStatutoryStartDateForm().bindFromRequest().fold(
+            (formWithErrors: Form[LocalDate]) =>
+              Future.successful(BadRequest(partnerStatutoryStartDate(appConfig, formWithErrors, mode, statutoryType))),
+            (value) =>
+              dataCacheConnector.save[LocalDate](request.sessionId, PartnerStatutoryStartDateId.toString, value).map(cacheMap =>
+                Redirect(navigator.nextPage(PartnerStatutoryStartDateId, mode)(new UserAnswers(cacheMap))))
+          )
+      }
   }
 }
 

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksController.scala
@@ -19,13 +19,15 @@ package uk.gov.hmrc.childcarecalculatorfrontend.controllers
 import javax.inject.Inject
 
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
+import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.DataCacheConnector
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryWeeksForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryWeeksId
+import uk.gov.hmrc.childcarecalculatorfrontend.models.requests.DataRequest
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryWeeks
@@ -40,29 +42,42 @@ class PartnerStatutoryWeeksController @Inject()(
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction) extends FrontendController with I18nSupport {
 
-  def onPageLoad(mode: Mode) = (getData andThen requireData) {
+  private def sessionExpired(implicit request: RequestHeader): Future[Result] =
+    Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
+
+  private def validateStatutoryPayType[A](block: (String) => Future[Result])
+                                         (implicit request: DataRequest[A]): Future[Result] = {
+
+    request.userAnswers.partnerStatutoryPayType.map {
+      payType => block(Messages(s"statutoryPayTypeLower.$payType"))
+    }.getOrElse(sessionExpired)
+  }
+
+  def onPageLoad(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.partnerStatutoryPayType.getOrElse("")
-
-      val preparedForm = request.userAnswers.partnerStatutoryWeeks match {
-        case None => PartnerStatutoryWeeksForm()
-        case Some(value) => PartnerStatutoryWeeksForm().fill(value)
+          val preparedForm = request.userAnswers.partnerStatutoryWeeks match {
+            case None => PartnerStatutoryWeeksForm()
+            case Some(value) => PartnerStatutoryWeeksForm().fill(value)
+          }
+          Future.successful(Ok(partnerStatutoryWeeks(appConfig, preparedForm, mode, statutoryType)))
       }
-      Ok(partnerStatutoryWeeks(appConfig, preparedForm, mode, statutoryType))
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.partnerStatutoryPayType.getOrElse("")
-
-      PartnerStatutoryWeeksForm().bindFromRequest().fold(
-        (formWithErrors: Form[Int]) =>
-          Future.successful(BadRequest(partnerStatutoryWeeks(appConfig, formWithErrors, mode, statutoryType))),
-        (value) =>
-          dataCacheConnector.save[Int](request.sessionId, PartnerStatutoryWeeksId.toString, value).map(cacheMap =>
-            Redirect(navigator.nextPage(PartnerStatutoryWeeksId, mode)(new UserAnswers(cacheMap))))
-      )
+          PartnerStatutoryWeeksForm().bindFromRequest().fold(
+            (formWithErrors: Form[Int]) =>
+              Future.successful(BadRequest(partnerStatutoryWeeks(appConfig, formWithErrors, mode, statutoryType))),
+            (value) =>
+              dataCacheConnector.save[Int](request.sessionId, PartnerStatutoryWeeksId.toString, value).map(cacheMap =>
+                Redirect(navigator.nextPage(PartnerStatutoryWeeksId, mode)(new UserAnswers(cacheMap))))
+          )
+      }
   }
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayTypeController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayTypeController.scala
@@ -26,7 +26,8 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayTypeForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.YourStatutoryPayTypeId
-import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{Mode, StatutoryPayTypeEnum}
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum.StatutoryPayTypeEnum
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryPayType
 
@@ -52,10 +53,10 @@ class YourStatutoryPayTypeController @Inject()(
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
       YourStatutoryPayTypeForm().bindFromRequest().fold(
-        (formWithErrors: Form[String]) =>
+        (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(yourStatutoryPayType(appConfig, formWithErrors, mode))),
         (value) =>
-          dataCacheConnector.save[String](request.sessionId, YourStatutoryPayTypeId.toString, value).map(cacheMap =>
+          dataCacheConnector.save[StatutoryPayTypeEnum.Value](request.sessionId, YourStatutoryPayTypeId.toString, value).map(cacheMap =>
             Redirect(navigator.nextPage(YourStatutoryPayTypeId, mode)(new UserAnswers(cacheMap))))
       )
   }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryStartDateController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryStartDateController.scala
@@ -20,14 +20,15 @@ import javax.inject.Inject
 
 import org.joda.time.LocalDate
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Result, RequestHeader}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
+import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.DataCacheConnector
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import uk.gov.hmrc.childcarecalculatorfrontend.{FrontendAppConfig, Navigator}
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryStartDateForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.YourStatutoryStartDateId
+import uk.gov.hmrc.childcarecalculatorfrontend.models.requests.DataRequest
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryStartDate
@@ -46,31 +47,39 @@ class YourStatutoryStartDateController @Inject()(
   private def sessionExpired(implicit request: RequestHeader): Future[Result] =
     Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
 
+  private def validateStatutoryPayType[A](block: (String) => Future[Result])
+                                         (implicit request: DataRequest[A]): Future[Result] = {
 
-  def onPageLoad(mode: Mode) = (getData andThen requireData) {
+    request.userAnswers.yourStatutoryPayType.map {
+      payType => block(Messages(s"statutoryPayTypeLower.$payType"))
+    }.getOrElse(sessionExpired)
+  }
+
+  def onPageLoad(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
-      val preparedForm = request.userAnswers.yourStatutoryStartDate match {
-        case None => YourStatutoryStartDateForm()
-        case Some(value) => YourStatutoryStartDateForm().fill(value)
-      }
+      validateStatutoryPayType {
+        statutoryType =>
 
-      request.userAnswers.yourStatutoryPayType match {
-        case Some(x) => Ok (yourStatutoryStartDate (appConfig, preparedForm, mode, x) )
-        case _ => Redirect(routes.SessionExpiredController.onPageLoad())
+          val preparedForm = request.userAnswers.yourStatutoryStartDate match {
+            case None => YourStatutoryStartDateForm()
+            case Some(value) => YourStatutoryStartDateForm().fill(value)
+          }
+          Future.successful(Ok(yourStatutoryStartDate (appConfig, preparedForm, mode, statutoryType)))
       }
   }
 
   def onSubmit(mode: Mode) = (getData andThen requireData).async {
     implicit request =>
+      validateStatutoryPayType {
+        statutoryType =>
 
-      val statutoryType = request.userAnswers.yourStatutoryPayType.getOrElse("")
-
-      YourStatutoryStartDateForm().bindFromRequest().fold(
-        (formWithErrors: Form[LocalDate]) =>
-          Future.successful(BadRequest(yourStatutoryStartDate(appConfig, formWithErrors, mode, statutoryType))),
-        (value) =>
-          dataCacheConnector.save[LocalDate](request.sessionId, YourStatutoryStartDateId.toString, value).map(cacheMap =>
-            Redirect(navigator.nextPage(YourStatutoryStartDateId, mode)(new UserAnswers(cacheMap))))
-      )
+          YourStatutoryStartDateForm().bindFromRequest().fold(
+            (formWithErrors: Form[LocalDate]) =>
+              Future.successful(BadRequest(yourStatutoryStartDate(appConfig, formWithErrors, mode, statutoryType))),
+            (value) =>
+              dataCacheConnector.save[LocalDate](request.sessionId, YourStatutoryStartDateId.toString, value).map(cacheMap =>
+                Redirect(navigator.nextPage(YourStatutoryStartDateId, mode)(new UserAnswers(cacheMap))))
+          )
+      }
   }
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryPayTypeForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryPayTypeForm.scala
@@ -19,30 +19,31 @@ package uk.gov.hmrc.childcarecalculatorfrontend.forms
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.data.format.Formatter
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants.unknownErrorKey
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.InputOption
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
 
 object PartnerStatutoryPayTypeForm extends FormErrorHelper {
 
-  def PartnerStatutoryPayTypeFormatter = new Formatter[String] {
+  val errorKey = "partnerStatutoryPayType.error"
+
+  def apply(): Form[StatutoryPayTypeEnum.Value] =
+    Form(single("value" -> of(StatutoryPayTypeFormatter)))
+
+  def options: Seq[InputOption] = StatutoryPayTypeEnum.values.map {
+    value =>
+      InputOption("statutoryPayType", value.toString)
+  }.toSeq
+
+  private def StatutoryPayTypeFormatter = new Formatter[StatutoryPayTypeEnum.Value] {
     def bind(key: String, data: Map[String, String]) = data.get(key) match {
-      case Some(s) if optionIsValid(s) => Right(s)
-      case None => produceError(key, partnerStatutoryPayTypeErrorKey)
-      case _ => produceError(key, "error.unknown")
+      case Some(s) if optionIsValid(s) => Right(StatutoryPayTypeEnum.withName(s))
+      case None => produceError(key, errorKey)
+      case _ => produceError(key, unknownErrorKey)
     }
 
-    def unbind(key: String, value: String) = Map(key -> value)
+    def unbind(key: String, value: StatutoryPayTypeEnum.Value) = Map(key -> value.toString)
   }
 
-  def apply(): Form[String] = 
-    Form(single("value" -> of(PartnerStatutoryPayTypeFormatter)))
-
-  def options = Seq(
-    InputOption("partnerStatutoryPayType", "maternity"),
-    InputOption("partnerStatutoryPayType", "paternity"),
-    InputOption("partnerStatutoryPayType", "adoption"),
-    InputOption("partnerStatutoryPayType", "shared-parental")
-  )
-
-  def optionIsValid(value: String) = options.exists(o => o.value == value)
+  private def optionIsValid(value: String) = options.exists(o => o.value == value)
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryPayTypeForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryPayTypeForm.scala
@@ -19,31 +19,32 @@ package uk.gov.hmrc.childcarecalculatorfrontend.forms
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.data.format.Formatter
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants.unknownErrorKey
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.InputOption
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
 
 
 object YourStatutoryPayTypeForm extends FormErrorHelper {
 
-  def YourStatutoryPayTypeFormatter = new Formatter[String] {
+  val errorKey = "yourStatutoryPayType.error"
+
+  def apply(): Form[StatutoryPayTypeEnum.Value] =
+    Form(single("value" -> of(StatutoryPayTypeFormatter)))
+
+  def options: Seq[InputOption] = StatutoryPayTypeEnum.values.map {
+    value =>
+      InputOption("statutoryPayType", value.toString)
+  }.toSeq
+
+  private def StatutoryPayTypeFormatter = new Formatter[StatutoryPayTypeEnum.Value] {
     def bind(key: String, data: Map[String, String]) = data.get(key) match {
-      case Some(s) if optionIsValid(s) => Right(s)
-      case None => produceError(key, yourStatutoryPayTypeErrorKey)
-      case _ => produceError(key, "error.unknown")
+      case Some(s) if optionIsValid(s) => Right(StatutoryPayTypeEnum.withName(s))
+      case None => produceError(key, errorKey)
+      case _ => produceError(key, unknownErrorKey)
     }
 
-    def unbind(key: String, value: String) = Map(key -> value)
+    def unbind(key: String, value: StatutoryPayTypeEnum.Value) = Map(key -> value.toString)
   }
 
-  def apply(): Form[String] = 
-    Form(single("value" -> of(YourStatutoryPayTypeFormatter)))
-
-  def options = Seq(
-    InputOption("yourStatutoryPayType", "maternity"),
-    InputOption("yourStatutoryPayType", "paternity"),
-    InputOption("yourStatutoryPayType", "adoption"),
-    InputOption("yourStatutoryPayType", "shared-parental")
-  )
-
-  def optionIsValid(value: String) = options.exists(o => o.value == value)
+  private def optionIsValid(value: String) = options.exists(o => o.value == value)
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryWeeksForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryWeeksForm.scala
@@ -16,32 +16,14 @@
 
 package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
-import play.api.data.{Form, FormError}
-import play.api.data.Forms._
-import play.api.data.format.Formatter
+import play.api.data.Form
 
 object YourStatutoryWeeksForm extends FormErrorHelper {
 
-  def yourStatutoryWeeksFormatter(errorKeyBlank: String, errorKeyDecimal: String, errorKeyNonNumeric: String) = new Formatter[Int] {
-
-    val intRegex = """^(\d+)$""".r
-    val decimalRegex = """^(\d*\.\d*)$""".r
-
-    def bind(key: String, data: Map[String, String]) = {
-      data.get(key) match {
-        case None => produceError(key, errorKeyBlank)
-        case Some("") => produceError(key, errorKeyBlank)
-        case Some(s) => s.trim.replace(",", "") match {
-          case intRegex(str) => Right(str.toInt)
-          case decimalRegex(_) => produceError(key, errorKeyDecimal)
-          case _ => produceError(key, errorKeyNonNumeric)
-        }
-      }
-    }
-
-    def unbind(key: String, value: Int) = Map(key -> value.toString)
-  }
-
-  def apply(errorKeyBlank: String = "error.required", errorKeyDecimal: String = "error.integer", errorKeyNonNumeric: String = "error.non_numeric"): Form[Int] =
-    Form(single("value" -> of(yourStatutoryWeeksFormatter(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric))))
+  def apply(statutoryType: String): Form[Int] =
+    Form(
+      "value" ->
+        int("yourStatutoryWeeks.required", "yourStatutoryWeeks.invalid", statutoryType)
+            .verifying(inRange[Int](1, 48, "yourStatutoryWeeks.invalid", statutoryType))
+    )
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
@@ -177,5 +177,16 @@ object PeriodEnum extends Enumeration {
   implicit def enumFormats: Format[PeriodEnum] = EnumUtils.enumFormat(PeriodEnum)
 }
 
+object StatutoryPayTypeEnum extends Enumeration {
+  type StatutoryPayTypeEnum = Value
+  val MATERNITY = Value("maternity")
+  val PATERNITY = Value("paternity")
+  val ADOPTION = Value("adoption")
+  val SHARED_PARENTAL = Value("shared-parental")
 
+  val enumReads: Reads[StatutoryPayTypeEnum] = EnumUtils.enumReads(StatutoryPayTypeEnum)
 
+  val enumWrites: Writes[StatutoryPayTypeEnum] = EnumUtils.enumWrites
+
+  implicit def enumFormats: Format[StatutoryPayTypeEnum] = EnumUtils.enumFormat(StatutoryPayTypeEnum)
+}

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/TaxYearInfo.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/TaxYearInfo.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.childcarecalculatorfrontend.utils
+
+import javax.inject.Inject
+
+import org.joda.time.DateTimeFieldType._
+import uk.gov.hmrc.time.TaxYearResolver
+
+class TaxYearInfo @Inject()() {
+
+  lazy val currentTaxYearStart: String = TaxYearResolver.startOfCurrentTaxYear.get(year).toString
+
+  lazy val currentTaxYearEnd: String = TaxYearResolver.endOfCurrentTaxYear.get(year).toString
+
+  lazy val previousTaxYearStart: String = (TaxYearResolver.startOfCurrentTaxYear.get(year) - 1).toString
+
+  lazy val previousTaxYearEnd: String = (TaxYearResolver.endOfCurrentTaxYear.get(year) - 1).toString
+}

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswers.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswers.scala
@@ -38,9 +38,9 @@ class UserAnswers(val cacheMap: CacheMap) extends MapFormats {
 
   def yourStatutoryWeeks: Option[Int] = cacheMap.getEntry[Int](YourStatutoryWeeksId.toString)
 
-  def yourStatutoryPayType: Option[String] = cacheMap.getEntry[String](YourStatutoryPayTypeId.toString)
+  def yourStatutoryPayType: Option[StatutoryPayTypeEnum.Value] = cacheMap.getEntry[StatutoryPayTypeEnum.Value](YourStatutoryPayTypeId.toString)
 
-  def partnerStatutoryPayType: Option[String] = cacheMap.getEntry[String](PartnerStatutoryPayTypeId.toString)
+  def partnerStatutoryPayType: Option[StatutoryPayTypeEnum.Value] = cacheMap.getEntry[StatutoryPayTypeEnum.Value](PartnerStatutoryPayTypeId.toString)
 
   def whoGotStatutoryPay: Option[YouPartnerBothEnum.Value] = cacheMap.getEntry[YouPartnerBothEnum.Value](WhoGotStatutoryPayId.toString)
   

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryPayBeforeTax.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryPayBeforeTax.scala.html
@@ -19,7 +19,6 @@
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayBeforeTaxForm
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.utils.FormHelpers
 @import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 
 @(appConfig: FrontendAppConfig, form: Form[String], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryPayType.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryPayType.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.childcarecalculatorfrontend.utils.FormHelpers
 @import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 
-@(appConfig: FrontendAppConfig, form: Form[String], mode: Mode)(implicit request: Request[_], messages: Messages)
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("partnerStatutoryPayType.title"),
@@ -38,7 +38,7 @@
     @helpers.form(action = PartnerStatutoryPayTypeController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.input_radio(
-            viewModel = InputViewModel[String]("value", form),
+            viewModel = InputViewModel("value", form),
             legend = messages("partnerStatutoryPayType.heading"),
             legendClass = Some("visually-hidden"),
             inputs = PartnerStatutoryPayTypeForm.options

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryStartDate.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryStartDate.scala.html
@@ -18,7 +18,6 @@
 @import uk.gov.hmrc.play.views.html._
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 @import org.joda.time.LocalDate
 
 @(appConfig: FrontendAppConfig, form: Form[LocalDate], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayBeforeTax.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayBeforeTax.scala.html
@@ -19,7 +19,6 @@
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayBeforeTaxForm
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.utils.FormHelpers
 @import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 
 @(appConfig: FrontendAppConfig, form: Form[String], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayPerWeek.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayPerWeek.scala.html
@@ -24,7 +24,6 @@
         form: Form[Int],
         mode: Mode,
         statutoryType: String)(implicit request: Request[_], messages: Messages)
-
 @main_template(
     title = messages("yourStatutoryPayPerWeek.title", statutoryType),
     appConfig = appConfig,

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayType.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryPayType.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.childcarecalculatorfrontend.utils.FormHelpers
 @import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 
-@(appConfig: FrontendAppConfig, form: Form[String], mode: Mode)(implicit request: Request[_], messages: Messages)
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("yourStatutoryPayType.title"),
@@ -38,7 +38,7 @@
     @helpers.form(action = YourStatutoryPayTypeController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.input_radio(
-            viewModel = InputViewModel[String]("value", form),
+            viewModel = InputViewModel("value", form),
             legend = messages("yourStatutoryPayType.heading"),
             legendClass = Some("visually-hidden"),
             inputs = YourStatutoryPayTypeForm.options

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryStartDate.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryStartDate.scala.html
@@ -18,7 +18,6 @@
 @import uk.gov.hmrc.play.views.html._
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
 @import org.joda.time.LocalDate
 
 @(appConfig: FrontendAppConfig, form: Form[LocalDate], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1044,26 +1044,27 @@ partnerStatutoryPay.required = Select yes if your partner had statutory pay sinc
 
 partnerStatutoryPayType.title = What kind of statutory pay did your partner get?
 partnerStatutoryPayType.heading = What kind of statutory pay did your partner get?
-partnerStatutoryPayType.maternity = maternity
-partnerStatutoryPayType.paternity = paternity
-partnerStatutoryPayType.adoption = adoption
-partnerStatutoryPayType.shared-parental = shared parental
 partnerStatutoryPayType.error = Select what kind of statutory pay your partner got
 partnerStatutoryPayType.checkYourAnswersLabel = partnerStatutoryPayType
 
 yourStatutoryPayType.title = What kind of statutory pay did you get?
 yourStatutoryPayType.heading = What kind of statutory pay did you get?
-yourStatutoryPayType.maternity = maternity
-yourStatutoryPayType.paternity = paternity
-yourStatutoryPayType.adoption = adoption
-yourStatutoryPayType.shared-parental = shared parental
 yourStatutoryPayType.error = Select what kind of statutory pay you got
-
 yourStatutoryPayType.checkYourAnswersLabel = yourStatutoryPayType
+
+statutoryPayType.maternity = Maternity
+statutoryPayType.paternity = Paternity
+statutoryPayType.adoption = Adoption
+statutoryPayType.shared-parental = Shared parental
+
+statutoryPayTypeLower.maternity = maternity
+statutoryPayTypeLower.paternity = paternity
+statutoryPayTypeLower.adoption = adoption
+statutoryPayTypeLower.shared-parental = shared parental
 
 yourStatutoryWeeks.title = How many weeks of {0} pay did you take?
 yourStatutoryWeeks.heading = How many weeks of {0} pay did you take?
-yourStatutoryWeeks.error = You must tell the calculator the number of weeks
+yourStatutoryWeeks.required = Enter how many weeks of {0} pay you took
 yourStatutoryWeeks.checkYourAnswersLabel = yourStatutoryWeeks
 
 partnerStatutoryWeeks.title = How many weeks of {0} pay did your partner take?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -634,6 +634,7 @@ parentPaidWorkPY.title = You are not working now, but have you had any paid work
 parentPaidWorkPY.heading = You are not working now, but have you had any paid work in the previous year?
 parentPaidWorkPY.checkYourAnswersLabel = You are not working now, but have you had any paid work in the previous year
 parentPaidWorkPY.error = You must tell the calculator if you had any paid work in the previous year
+
 parentPaidWorkPY.currentYear.startEndDate = This year is 6 April 2016 to 5 April 2017.
 
 partnerPaidWorkPY.title = Your partner isn’t working now, but have they had any paid work in the previous year?
@@ -1016,11 +1017,12 @@ whoGotStatutoryPay.heading = Who got statutory pay?
 whoGotStatutoryPay.you = You
 whoGotStatutoryPay.partner = Partner
 whoGotStatutoryPay.both = Both
-whoGotStatutoryPay.error = You must tell the calculator who got statutory pay
+whoGotStatutoryPay.error = Select who got statutory pay
 
 youStatutoryPay.title = Have you had statutory pay since 6 April 2016?
 youStatutoryPay.heading = Have you had statutory pay since 6 April 2016?
 youStatutoryPay.checkYourAnswersLabel = Have you had statutory pay since 6 April 2016?
+youStatutoryPay.required = Select yes if you have had statutory pay since 6 April {0}
 
 statutoryPay.guidance = Statutory pay is:
 statutoryPay.li.maternity = maternity
@@ -1032,11 +1034,13 @@ statutoryPay.guidance_extra = It could have started before this date and overlap
 bothStatutoryPay.title = Have you, your partner, or both of you had statutory pay since 6 April 2016?
 bothStatutoryPay.heading = Have you, your partner, or both of you had statutory pay since 6 April 2016?
 bothStatutoryPay.checkYourAnswersLabel = Have you, your partner, or both of you had statutory pay since 6 April 2016?
+bothStatutoryPay.required = Select yes if you, your partner, or both of you have had statutory pay since 6th April {0}
 
 partnerStatutoryPay.title = Has your partner had statutory pay since 6 April 2016?
 partnerStatutoryPay.heading = Has your partner had statutory pay since 6 April 2016?
 partnerStatutoryPay.checkYourAnswersLabel = Has your partner had statutory pay since 6 April 2016?
 partnerStatutoryPay.guidance_extra = This could also be if they started to get the pay before 6 April 2016 and continued to get it after this date.
+partnerStatutoryPay.required = Select yes if your partner had statutory pay since 6 April {0}
 
 partnerStatutoryPayType.title = What kind of statutory pay did your partner get?
 partnerStatutoryPayType.heading = What kind of statutory pay did your partner get?
@@ -1044,7 +1048,7 @@ partnerStatutoryPayType.maternity = maternity
 partnerStatutoryPayType.paternity = paternity
 partnerStatutoryPayType.adoption = adoption
 partnerStatutoryPayType.shared-parental = shared parental
-partnerStatutoryPayType.error = You must tell the calculator what kind of statutory pay your partner got
+partnerStatutoryPayType.error = Select what kind of statutory pay your partner got
 partnerStatutoryPayType.checkYourAnswersLabel = partnerStatutoryPayType
 
 yourStatutoryPayType.title = What kind of statutory pay did you get?
@@ -1053,7 +1057,8 @@ yourStatutoryPayType.maternity = maternity
 yourStatutoryPayType.paternity = paternity
 yourStatutoryPayType.adoption = adoption
 yourStatutoryPayType.shared-parental = shared parental
-yourStatutoryPayType.error = You must tell the calculator what kind of statutory pay you got
+yourStatutoryPayType.error = Select what kind of statutory pay you got
+
 yourStatutoryPayType.checkYourAnswersLabel = yourStatutoryPayType
 
 yourStatutoryWeeks.title = How many weeks of {0} pay did you take?

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/BothStatutoryPayControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/BothStatutoryPayControllerSpec.scala
@@ -26,17 +26,22 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.BooleanForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.BothStatutoryPayId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.TaxYearInfo
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.bothStatutoryPay
 
 class BothStatutoryPayControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
+  val taxYearInfo = new TaxYearInfo()
+
+  def myForm: Form[Boolean] = BooleanForm("bothStatutoryPay.required", taxYearInfo.previousTaxYearStart)
+
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new BothStatutoryPayController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
-      dataRetrievalAction, new DataRequiredActionImpl)
+      dataRetrievalAction, new DataRequiredActionImpl, taxYearInfo)
 
-  def viewAsString(form: Form[Boolean] = BooleanForm()) = bothStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Boolean] = myForm) = bothStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "BothStatutoryPay Controller" must {
 
@@ -53,7 +58,7 @@ class BothStatutoryPayControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(BooleanForm().fill(true))
+      contentAsString(result) mustBe viewAsString(myForm.fill(true))
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -67,7 +72,7 @@ class BothStatutoryPayControllerSpec extends ControllerSpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
-      val boundForm = BooleanForm().bind(Map("value" -> "invalid value"))
+      val boundForm = myForm.bind(Map("value" -> "invalid value"))
 
       val result = controller().onSubmit(NormalMode)(postRequest)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ControllerSpecBase.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ControllerSpecBase.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.JsString
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.childcarecalculatorfrontend.SpecBase
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions.FakeDataRetrievalAction
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
 
 trait ControllerSpecBase extends SpecBase {
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayBeforeTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayBeforeTaxControllerSpec.scala
@@ -25,16 +25,20 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayBeforeTaxForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.{PartnerStatutoryPayBeforeTaxId, PartnerStatutoryPayTypeId}
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayBeforeTax
 
 class PartnerStatutoryPayBeforeTaxControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new PartnerStatutoryPayBeforeTaxController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayControllerSpec.scala
@@ -26,17 +26,22 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.BooleanForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryPayId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.TaxYearInfo
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPay
 
 class PartnerStatutoryPayControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
+  val taxYearInfo = new TaxYearInfo()
+
+  def myForm: Form[Boolean] = BooleanForm("partnerStatutoryPay.required", taxYearInfo.previousTaxYearStart)
+
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new PartnerStatutoryPayController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
-      dataRetrievalAction, new DataRequiredActionImpl)
+      dataRetrievalAction, new DataRequiredActionImpl, taxYearInfo)
 
-  def viewAsString(form: Form[Boolean] = BooleanForm()) = partnerStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Boolean] = myForm) = partnerStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "PartnerStatutoryPay Controller" must {
 
@@ -67,7 +72,7 @@ class PartnerStatutoryPayControllerSpec extends ControllerSpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
-      val boundForm = BooleanForm().bind(Map("value" -> "invalid value"))
+      val boundForm = myForm.bind(Map("value" -> "invalid value"))
 
       val result = controller().onSubmit(NormalMode)(postRequest)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayPerWeekControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayPerWeekControllerSpec.scala
@@ -32,9 +32,13 @@ class PartnerStatutoryPayPerWeekControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new PartnerStatutoryPayPerWeekController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryPayTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayTypeForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.PartnerStatutoryPayTypeId
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayType
 
 class PartnerStatutoryPayTypeControllerSpec extends ControllerSpecBase {
@@ -36,7 +36,7 @@ class PartnerStatutoryPayTypeControllerSpec extends ControllerSpecBase {
     new PartnerStatutoryPayTypeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 
-  def viewAsString(form: Form[String] = PartnerStatutoryPayTypeForm()) = partnerStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+  def viewAsString(form: Form[StatutoryPayTypeEnum.Value] = PartnerStatutoryPayTypeForm()) = partnerStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "PartnerStatutoryPayType Controller" must {
 
@@ -53,7 +53,7 @@ class PartnerStatutoryPayTypeControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(PartnerStatutoryPayTypeForm().fill(PartnerStatutoryPayTypeForm.options.head.value))
+      contentAsString(result) mustBe viewAsString(PartnerStatutoryPayTypeForm().fill(StatutoryPayTypeEnum.MATERNITY))
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryStartDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryStartDateControllerSpec.scala
@@ -33,9 +33,13 @@ class PartnerStatutoryStartDateControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new PartnerStatutoryStartDateController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 
@@ -97,7 +101,7 @@ class PartnerStatutoryStartDateControllerSpec extends ControllerSpecBase {
     }
 
     "redirect to Session Expired for a POST if no existing data is found" in {
-      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", statutoryType))
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", statutoryType.toString))
       val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
 
       status(result) mustBe SEE_OTHER

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksControllerSpec.scala
@@ -32,9 +32,13 @@ class PartnerStatutoryWeeksControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString() -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(PartnerStatutoryPayTypeId.toString() -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new PartnerStatutoryWeeksController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YouStatutoryPayControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YouStatutoryPayControllerSpec.scala
@@ -26,17 +26,22 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.BooleanForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.YouStatutoryPayId
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.TaxYearInfo
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.youStatutoryPay
 
 class YouStatutoryPayControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
+  val taxYearInfo = new TaxYearInfo()
+
+  def myForm: Form[Boolean] = BooleanForm("youStatutoryPay.required", taxYearInfo.previousTaxYearStart)
+
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
     new YouStatutoryPayController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
-      dataRetrievalAction, new DataRequiredActionImpl)
+      dataRetrievalAction, new DataRequiredActionImpl, taxYearInfo)
 
-  def viewAsString(form: Form[Boolean] = BooleanForm()) = youStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Boolean] = myForm) = youStatutoryPay(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "youStatutoryPay Controller" must {
 
@@ -53,7 +58,7 @@ class YouStatutoryPayControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(BooleanForm().fill(true))
+      contentAsString(result) mustBe viewAsString(myForm.fill(true))
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -67,7 +72,7 @@ class YouStatutoryPayControllerSpec extends ControllerSpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
-      val boundForm = BooleanForm().bind(Map("value" -> "invalid value"))
+      val boundForm = myForm.bind(Map("value" -> "invalid value"))
 
       val result = controller().onSubmit(NormalMode)(postRequest)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayBeforeTaxControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayBeforeTaxControllerSpec.scala
@@ -32,9 +32,13 @@ class YourStatutoryPayBeforeTaxControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new YourStatutoryPayBeforeTaxController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayPerWeekControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayPerWeekControllerSpec.scala
@@ -36,11 +36,15 @@ import uk.gov.hmrc.childcarecalculatorfrontend.views.html.{yourStatutoryPayPerWe
 
 class YourStatutoryPayPerWeekControllerSpec extends ControllerSpecBase with MockitoSugar{
 
-  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
+
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new YourStatutoryPayPerWeekController(frontendAppConfig,
       messagesApi,
       FakeDataCacheConnector,

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryPayTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions._
 import play.api.test.Helpers._
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayTypeForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.YourStatutoryPayTypeId
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryPayType
 
 class YourStatutoryPayTypeControllerSpec extends ControllerSpecBase {
@@ -36,7 +36,7 @@ class YourStatutoryPayTypeControllerSpec extends ControllerSpecBase {
     new YourStatutoryPayTypeController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 
-  def viewAsString(form: Form[String] = YourStatutoryPayTypeForm()) = yourStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+  def viewAsString(form: Form[_] = YourStatutoryPayTypeForm()) = yourStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
 
   "YourStatutoryPayType Controller" must {
 
@@ -53,7 +53,7 @@ class YourStatutoryPayTypeControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(YourStatutoryPayTypeForm().fill(YourStatutoryPayTypeForm.options.head.value))
+      contentAsString(result) mustBe viewAsString(YourStatutoryPayTypeForm().fill(StatutoryPayTypeEnum.MATERNITY))
     }
 
     "redirect to the next page when valid data is submitted" in {

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryStartDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryStartDateControllerSpec.scala
@@ -33,9 +33,13 @@ class YourStatutoryStartDateControllerSpec extends ControllerSpecBase {
 
   def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new YourStatutoryStartDateController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryWeeksControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryWeeksControllerSpec.scala
@@ -32,13 +32,17 @@ class YourStatutoryWeeksControllerSpec extends ControllerSpecBase {
 
   private def onwardRoute = routes.WhatToTellTheCalculatorController.onPageLoad()
 
-  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType))
+  private val statutoryTypeNameValuePair = Map(YourStatutoryPayTypeId.toString -> JsString(statutoryType.toString))
 
-  private def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+  private val retrievalAction = new FakeDataRetrievalAction(
+    Some(CacheMap("id", statutoryTypeNameValuePair))
+  )
+
+  private def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new YourStatutoryWeeksController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl)
 
-  def viewAsString(form: Form[Int] = YourStatutoryWeeksForm()) = yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Int] = YourStatutoryWeeksForm(statutoryType)) = yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType)(fakeRequest, messages).toString
 
   val testNumber = 123
 
@@ -57,7 +61,7 @@ class YourStatutoryWeeksControllerSpec extends ControllerSpecBase {
 
       val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
 
-      contentAsString(result) mustBe viewAsString(YourStatutoryWeeksForm().fill(testNumber))
+      contentAsString(result) mustBe viewAsString(YourStatutoryWeeksForm(statutoryType).fill(testNumber))
     }
 
     "redirect to the next page when valid data is submitted" in {
@@ -72,7 +76,7 @@ class YourStatutoryWeeksControllerSpec extends ControllerSpecBase {
     "return a Bad Request and errors when invalid data is submitted" in {
 
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
-      val boundForm = YourStatutoryWeeksForm().bind(Map("value" -> "invalid value"))
+      val boundForm = YourStatutoryWeeksForm(statutoryType).bind(Map("value" -> "invalid value"))
 
       val result = controller(buildFakeRequest(statutoryTypeNameValuePair)).onSubmit(NormalMode)(postRequest)
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryPayTypeFormSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryPayTypeFormSpec.scala
@@ -17,19 +17,20 @@
 package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.behaviours.FormBehaviours
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
 
 
 class PartnerStatutoryPayTypeFormSpec extends FormBehaviours {
 
   val validData: Map[String, String] = Map(
-    "value" -> PartnerStatutoryPayTypeForm.options.head.value
+    "value" -> StatutoryPayTypeEnum.MATERNITY.toString
   )
 
   val form = PartnerStatutoryPayTypeForm()
 
   "PartnerStatutoryPayType form" must {
-    behave like questionForm[String](PartnerStatutoryPayTypeForm.options.head.value)
+    behave like questionForm[StatutoryPayTypeEnum.Value](StatutoryPayTypeEnum.MATERNITY)
 
     behave like formWithOptionFieldError("value", partnerStatutoryPayTypeErrorKey, PartnerStatutoryPayTypeForm.options.map{x => x.value}:_*)
   }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryPayTypeFormSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryPayTypeFormSpec.scala
@@ -17,19 +17,20 @@
 package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.behaviours.FormBehaviours
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
 
 
 class YourStatutoryPayTypeFormSpec extends FormBehaviours {
 
   val validData: Map[String, String] = Map(
-    "value" -> YourStatutoryPayTypeForm.options.head.value
+    "value" -> StatutoryPayTypeEnum.MATERNITY.toString
   )
 
   val form = YourStatutoryPayTypeForm()
 
   "YourStatutoryPayType form" must {
-    behave like questionForm[String](YourStatutoryPayTypeForm.options.head.value)
+    behave like questionForm[StatutoryPayTypeEnum.Value](StatutoryPayTypeEnum.MATERNITY)
 
     behave like formWithOptionFieldError("value", yourStatutoryPayTypeErrorKey ,YourStatutoryPayTypeForm.options.map{x => x.value}:_*)
   }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryWeeksFormSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryWeeksFormSpec.scala
@@ -18,50 +18,40 @@ package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
 class YourStatutoryWeeksFormSpec extends FormSpec {
 
-  val errorKeyBlank = "blank"
-  val errorKeyDecimal = "decimal"
-  val errorKeyNonNumeric = "must be a whole number"
+  val statutoryType = "maternity"
+  val errorInvalid = error("value", "yourStatutoryWeeks.invalid", statutoryType)
+  val errorRequired = error("value", "yourStatutoryWeeks.required", statutoryType)
+
 
   "YourStatutoryWeeks Form" must {
 
-    "bind zero" in {
-      val form = YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric).bind(Map("value" -> "0"))
-      form.get shouldBe 0
-    }
-
-    "bind positive numbers" in {
-      val form = YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric).bind(Map("value" -> "1"))
+    "bind numbers within range" in {
+      val form = YourStatutoryWeeksForm(statutoryType).bind(Map("value" -> "1"))
       form.get shouldBe 1
     }
 
-    "bind positive, comma separated numbers" in {
-      val form = YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric).bind(Map("value" -> "10,000"))
-      form.get shouldBe 10000
+    "fail to bind numbers below the threshold" in {
+      checkForError(YourStatutoryWeeksForm(statutoryType), Map("value" -> "0"), errorInvalid)
     }
 
-    "fail to bind negative numbers" in {
-      val expectedError = error("value", errorKeyNonNumeric)
-      checkForError(YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric), Map("value" -> "-1"), expectedError)
+    "fail to bind numbers above the threshold" in {
+      checkForError(YourStatutoryWeeksForm(statutoryType), Map("value" -> "49"), errorInvalid)
     }
 
     "fail to bind non-numerics" in {
-      val expectedError = error("value", errorKeyNonNumeric)
-      checkForError(YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric), Map("value" -> "not a number"), expectedError)
+      checkForError(YourStatutoryWeeksForm(statutoryType), Map("value" -> "not a number"), errorInvalid)
     }
 
     "fail to bind a blank value" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric), Map("value" -> ""), expectedError)
+      checkForError(YourStatutoryWeeksForm(statutoryType), Map("value" -> ""), errorRequired)
     }
 
     "fail to bind when value is omitted" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric), emptyForm, expectedError)
+      checkForError(YourStatutoryWeeksForm(statutoryType), emptyForm, errorRequired)
     }
 
     "fail to bind decimal numbers" in {
-      val expectedError = error("value", errorKeyDecimal)
-      checkForError(YourStatutoryWeeksForm(errorKeyBlank, errorKeyDecimal, errorKeyNonNumeric), Map("value" -> "123.45"), expectedError)
+      checkForError(YourStatutoryWeeksForm(statutoryType), Map("value" -> "123.45"), errorInvalid)
     }
   }
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/navigation/StatutoryNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/navigation/StatutoryNavigatorSpec.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.JsValue
 import uk.gov.hmrc.childcarecalculatorfrontend.SpecBase
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers._
-import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, YouPartnerBothEnum}
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum, YouPartnerBothEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.schemes._
 import uk.gov.hmrc.childcarecalculatorfrontend.models.schemes.tc.ModelFactory
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.{UserAnswers, Utils}
@@ -137,7 +137,10 @@ class StatutoryNavigatorSpec extends SpecBase with MockitoSugar {
         "redirects to yourStatutoryStartDate page when user selects some value" in {
           val answers = spy(userAnswers())
           when(answers.yourStatutoryPayType) thenReturn
-            Some("maternity") thenReturn Some("paternity") thenReturn Some("adoption") thenReturn Some("shared parental")
+            Some(StatutoryPayTypeEnum.MATERNITY) thenReturn
+            Some(StatutoryPayTypeEnum.PATERNITY) thenReturn
+            Some(StatutoryPayTypeEnum.ADOPTION) thenReturn
+            Some(StatutoryPayTypeEnum.SHARED_PARENTAL)
 
           navigator.nextPage(YourStatutoryPayTypeId, NormalMode).value(answers) mustBe
             routes.YourStatutoryStartDateController.onPageLoad(NormalMode)
@@ -171,7 +174,10 @@ class StatutoryNavigatorSpec extends SpecBase with MockitoSugar {
         "redirects to partnerStatutoryStartDate page when user selects some value" in {
           val answers = spy(userAnswers())
           when(answers.partnerStatutoryPayType) thenReturn
-            Some("maternity") thenReturn Some("paternity") thenReturn Some("adoption") thenReturn Some("shared parental")
+            Some(StatutoryPayTypeEnum.MATERNITY) thenReturn
+            Some(StatutoryPayTypeEnum.PATERNITY) thenReturn
+            Some(StatutoryPayTypeEnum.ADOPTION) thenReturn
+            Some(StatutoryPayTypeEnum.SHARED_PARENTAL)
 
           navigator.nextPage(PartnerStatutoryPayTypeId, NormalMode).value(answers) mustBe
             routes.PartnerStatutoryStartDateController.onPageLoad(NormalMode)

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayBeforeTaxViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayBeforeTaxViewSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayBeforeTaxForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.ViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayBeforeTax
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayPerWeekViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayPerWeekViewSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryPayPerWeekForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryPayPerWeek
 
@@ -49,6 +49,6 @@ class PartnerStatutoryPayPerWeekViewSpec extends IntViewBehaviours {
       createViewUsingForm,
       messageKeyPrefix,
       routes.PartnerStatutoryPayPerWeekController.onSubmit(NormalMode).url,
-      messageDynamicValue = Some(statutoryType))
+      messageDynamicValue = Some(statutoryType.toString))
   }
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryPayTypeViewSpec.scala
@@ -28,7 +28,7 @@ class PartnerStatutoryPayTypeViewSpec extends ViewBehaviours {
 
   def createView = () => partnerStatutoryPayType(frontendAppConfig, PartnerStatutoryPayTypeForm(), NormalMode)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[String]) => partnerStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createViewUsingForm = (form: Form[_]) => partnerStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
   "PartnerStatutoryPayType view" must {
     behave like normalPage(createView, messageKeyPrefix)

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryStartDateViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryStartDateViewSpec.scala
@@ -20,7 +20,7 @@ import org.joda.time.LocalDate
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryStartDateForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.DateViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryStartDate
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryWeeksViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryWeeksViewSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryWeeksForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryWeeks
 
@@ -48,6 +48,6 @@ class PartnerStatutoryWeeksViewSpec extends IntViewBehaviours {
     behave like intPage(createViewUsingForm,
       messageKeyPrefix,
       routes.PartnerStatutoryWeeksController.onSubmit(NormalMode).url,
-      messageDynamicValue = Some(statutoryType))
+      messageDynamicValue = Some(statutoryType.toString))
   }
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayBeforeTaxViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayBeforeTaxViewSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayBeforeTaxForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.ViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryPayBeforeTax
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayPerWeekViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayPerWeekViewSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayPerWeekForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryPayPerWeek
 
@@ -52,7 +52,7 @@ class YourStatutoryPayPerWeekViewSpec extends IntViewBehaviours {
       createViewUsingForm,
       messageKeyPrefix,
       routes.YourStatutoryPayPerWeekController.onSubmit(NormalMode).url,
-      messageDynamicValue = Some(statutoryType))
+      messageDynamicValue = Some(statutoryType.toString))
   }
 
   "show correct statutory pay type" in {

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryPayTypeViewSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryPayTypeForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.ViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryPayType
 
@@ -26,9 +26,11 @@ class YourStatutoryPayTypeViewSpec extends ViewBehaviours {
 
   val messageKeyPrefix = "yourStatutoryPayType"
 
+  val statutoryType = StatutoryPayTypeEnum.MATERNITY
+
   def createView = () => yourStatutoryPayType(frontendAppConfig, YourStatutoryPayTypeForm(), NormalMode)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[String]) => yourStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createViewUsingForm = (form: Form[_]) => yourStatutoryPayType(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
   "YourStatutoryPayType view" must {
     behave like normalPage(createView, messageKeyPrefix)

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryStartDateViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryStartDateViewSpec.scala
@@ -20,7 +20,7 @@ import org.joda.time.LocalDate
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryStartDateForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.DateViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryStartDate
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryWeeksViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryWeeksViewSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.views
 import play.api.data.Form
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryWeeksForm
-import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{NormalMode, StatutoryPayTypeEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryWeeks
 
@@ -29,7 +29,7 @@ class YourStatutoryWeeksViewSpec extends IntViewBehaviours {
 
   val statutoryType = "maternity"
 
-  val form = YourStatutoryWeeksForm()
+  val form = YourStatutoryWeeksForm(statutoryType)
 
   def createView = () => yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType)(fakeRequest, messages)
 


### PR DESCRIPTION
Part of the work for CCALC-3714, to update validation on the statutory pay screens.  The ticket will be split into multiple PR's due to the volume of code affected.

This PR updates some validation, introduces a way to get dynamic tax year information, and changes "statutory pay type" to be an enum instead of a string.