### PR TITLE
CCALC-3802 Add guidance on statutory weeks pages

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/viewmodels/StatutoryPayWeeksViewModel.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/viewmodels/StatutoryPayWeeksViewModel.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.childcarecalculatorfrontend.viewmodels
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.childcarecalculatorfrontend.FrontendAppConfig
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum
+import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum._
+
+class StatutoryPayWeeksViewModel (appConfig: FrontendAppConfig, statutoryType: StatutoryPayTypeEnum.Value)(implicit messages: Messages) {
+
+  val maxWeeks = statutoryType match {
+    case MATERNITY => appConfig.maxNoWeeksMaternityPay
+    case PATERNITY => appConfig.maxNoWeeksPaternityPay
+    case ADOPTION => appConfig.maxNoWeeksAdoptionPay
+    case SHARED_PARENTAL => appConfig.maxNoWeeksSharedParentalPay
+  }
+
+  val statutoryTypeMessage: String = Messages(s"statutoryPayTypeLower.$statutoryType")
+
+  val guidanceKey: String = statutoryType.toString
+}

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryWeeks.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerStatutoryWeeks.scala.html
@@ -18,12 +18,12 @@
 @import uk.gov.hmrc.play.views.html._
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
+@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.{InputViewModel, StatutoryPayWeeksViewModel}
 
-@(appConfig: FrontendAppConfig, form: Form[Int], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)
+@(appConfig: FrontendAppConfig, form: Form[Int], mode: Mode, viewModel: StatutoryPayWeeksViewModel)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("partnerStatutoryWeeks.title", statutoryType),
+    title = messages("partnerStatutoryWeeks.title", viewModel.statutoryTypeMessage),
     appConfig = appConfig,
     bodyClasses = None) {
 
@@ -31,12 +31,14 @@
 
     @components.error_summary(form.errors)
 
-    @components.heading(messages("partnerStatutoryWeeks.heading", statutoryType), "heading-xlarge")
+    @components.heading(messages("partnerStatutoryWeeks.heading", viewModel.statutoryTypeMessage), "heading-xlarge")
+
+    <p>@messages(s"statutoryWeeks.${viewModel.guidanceKey}.guidance", viewModel.maxWeeks)</p>
 
     @helpers.form(action = PartnerStatutoryWeeksController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.input_number(InputViewModel[Int]("value", form),
-            label = messages("partnerStatutoryWeeks.heading", statutoryType),
+            label = messages("partnerStatutoryWeeks.heading", viewModel.statutoryTypeMessage),
             labelClass=Some("visually-hidden"))
 
         @components.submit_button()

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryWeeks.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourStatutoryWeeks.scala.html
@@ -18,12 +18,12 @@
 @import uk.gov.hmrc.play.views.html._
 @import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 @import uk.gov.hmrc.childcarecalculatorfrontend.models.Mode
-@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.InputViewModel
+@import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.{InputViewModel, StatutoryPayWeeksViewModel}
 
-@(appConfig: FrontendAppConfig, form: Form[Int], mode: Mode, statutoryType: String)(implicit request: Request[_], messages: Messages)
+@(appConfig: FrontendAppConfig, form: Form[Int], mode: Mode, viewModel: StatutoryPayWeeksViewModel)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("yourStatutoryWeeks.title", statutoryType),
+    title = messages("yourStatutoryWeeks.title", viewModel.statutoryTypeMessage),
     appConfig = appConfig,
     bodyClasses = None) {
 
@@ -31,12 +31,14 @@
 
     @components.error_summary(form.errors)
 
-    @components.heading(messages("yourStatutoryWeeks.heading", statutoryType), "heading-xlarge")
+    @components.heading(messages("yourStatutoryWeeks.heading", viewModel.statutoryTypeMessage), "heading-xlarge")
+
+    <p>@messages(s"statutoryWeeks.${viewModel.guidanceKey}.guidance", viewModel.maxWeeks)</p>
 
     @helpers.form(action = YourStatutoryWeeksController.onSubmit(mode), 'autoComplete -> "off") {
 
         @components.input_number(InputViewModel[Int]("value", form),
-            label = messages("yourStatutoryWeeks.heading", statutoryType),
+            label = messages("yourStatutoryWeeks.heading", viewModel.statutoryTypeMessage),
             labelClass=Some("visually-hidden"))
 
         @components.submit_button()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1089,6 +1089,11 @@ partnerStatutoryWeeks.required = Enter how many weeks of {2} pay your partner to
 partnerStatutoryWeeks.invalid = Enter numbers between {0} and {1} for how many weeks of {2} pay your partner took
 partnerStatutoryWeeks.checkYourAnswersLabel = partnerStatutoryWeeks
 
+statutoryWeeks.maternity.guidance = This is usually taken as {0} weeks
+statutoryWeeks.paternity.guidance = This is usually taken as {0} weeks
+statutoryWeeks.adoption.guidance = This is usually taken as {0} weeks
+statutoryWeeks.shared-parental.guidance = This is usually taken as {0} weeks between both parents
+
 yourStatutoryStartDate.title = When did your {0} pay start?
 yourStatutoryStartDate.heading = When did your {0} pay start?
 yourStatutoryStartDate.error.required = Enter the date your {0} pay started

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/SpecBase.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/SpecBase.scala
@@ -32,5 +32,5 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite {
 
   def fakeRequest = FakeRequest("", "")
 
-  def messages: Messages = messagesApi.preferred(fakeRequest)
+  implicit def messages: Messages = messagesApi.preferred(fakeRequest)
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/PartnerStatutoryWeeksControllerSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryWeeksForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.{PartnerStatutoryPayTypeId, PartnerStatutoryWeeksId}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
 import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum.MATERNITY
+import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.StatutoryPayWeeksViewModel
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryWeeks
 
 class PartnerStatutoryWeeksControllerSpec extends ControllerSpecBase {
@@ -41,11 +42,13 @@ class PartnerStatutoryWeeksControllerSpec extends ControllerSpecBase {
 
   val form = new PartnerStatutoryWeeksForm(frontendAppConfig).apply(MATERNITY, statutoryType.toString)
 
+  val viewModel = new StatutoryPayWeeksViewModel(frontendAppConfig, MATERNITY)
+
   def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new PartnerStatutoryWeeksController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl, new PartnerStatutoryWeeksForm(frontendAppConfig))
 
-  def viewAsString(form: Form[Int] = form) = partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Int] = form) = partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages).toString
 
   val testNumber = 1
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryWeeksControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/YourStatutoryWeeksControllerSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryWeeksForm
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.{YourStatutoryPayTypeId, YourStatutoryWeeksId}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
 import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum._
+import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.StatutoryPayWeeksViewModel
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryWeeks
 
 class YourStatutoryWeeksControllerSpec extends ControllerSpecBase {
@@ -41,11 +42,13 @@ class YourStatutoryWeeksControllerSpec extends ControllerSpecBase {
 
   val form = new YourStatutoryWeeksForm(frontendAppConfig).apply(MATERNITY, statutoryType.toString)
 
+  val viewModel = new StatutoryPayWeeksViewModel(frontendAppConfig, MATERNITY)
+
   private def controller(dataRetrievalAction: DataRetrievalAction = retrievalAction) =
     new YourStatutoryWeeksController(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute),
       dataRetrievalAction, new DataRequiredActionImpl, new YourStatutoryWeeksForm(frontendAppConfig))
 
-  def viewAsString(form: Form[Int] = form) = yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType)(fakeRequest, messages).toString
+  def viewAsString(form: Form[Int] = form) = yourStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages).toString
 
   val testNumber = 1
 

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryWeeksViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/PartnerStatutoryWeeksViewSpec.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.PartnerStatutoryWeeksForm
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
 import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum.MATERNITY
+import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.StatutoryPayWeeksViewModel
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.partnerStatutoryWeeks
 
@@ -33,9 +34,11 @@ class PartnerStatutoryWeeksViewSpec extends IntViewBehaviours {
 
   val messageKeyPrefix = "partnerStatutoryWeeks"
 
-  def createView = () => partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType.toString)(fakeRequest, messages)
+  val viewModel = new StatutoryPayWeeksViewModel(frontendAppConfig, statutoryType)
 
-  def createViewUsingForm = (form: Form[Int]) => partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType.toString)(fakeRequest, messages)
+  def createView = () => partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[Int]) => partnerStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages)
 
   "PartnerStatutoryWeeks view" must {
     behave like normalPageWithTitleAsString(

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryWeeksViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/YourStatutoryWeeksViewSpec.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.forms.YourStatutoryWeeksForm
 import uk.gov.hmrc.childcarecalculatorfrontend.models.NormalMode
 import uk.gov.hmrc.childcarecalculatorfrontend.models.StatutoryPayTypeEnum.MATERNITY
+import uk.gov.hmrc.childcarecalculatorfrontend.viewmodels.StatutoryPayWeeksViewModel
 import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.IntViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.yourStatutoryWeeks
 
@@ -32,9 +33,11 @@ class YourStatutoryWeeksViewSpec extends IntViewBehaviours {
 
   val form = new YourStatutoryWeeksForm(frontendAppConfig).apply(statutoryType, statutoryType.toString)
 
-  def createView = () => yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType.toString)(fakeRequest, messages)
+  val viewModel = new StatutoryPayWeeksViewModel(frontendAppConfig, statutoryType)
 
-  def createViewUsingForm = (form: Form[Int]) => yourStatutoryWeeks(frontendAppConfig, form, NormalMode, statutoryType.toString)(fakeRequest, messages)
+  def createView = () => yourStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[Int]) => yourStatutoryWeeks(frontendAppConfig, form, NormalMode, viewModel)(fakeRequest, messages)
 
   "YourStatutoryWeeks view" must {
 


### PR DESCRIPTION
Because the guidance text is dynamic and we are already dealing with
dynamic content on this page, we introduce a view model to encapsulate some
of the logic around building the correct messages