### PR TITLE
results page title change

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
@@ -34,21 +34,19 @@
 }
 
 @main_template(
-    title = heading.toString().trim,
+    title = messages("result.title"),
     appConfig = appConfig,
     bodyClasses = Some("result")) {
 
-
     @components.back_link()
 
-
-    <h1 class="heading-xlarge">@heading</h1>
+    @components.heading("result.heading", "heading-xlarge")
 
     <p>@model.firstParagraph</p>
 
     @if(model.noOfEligibleSchemes > 0) {
 
-        <h2 class="resultEligibleHeading visuallyhidden">@messages("result.eligible.heading")</h2>
+        <h2 class="resultEligibleHeading visuallyhidden">@heading</h2>
 
         @resultEligible(model, utils)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1184,6 +1184,8 @@ partnerStatutoryPayPerWeek.checkYourAnswersLabel = How much {0} pay did your par
 partnerStatutoryPayPerWeek.required = Enter how much {0} pay your partner got a week
 partnerStatutoryPayPerWeek.invalid = Enter numbers from 1 to 99.99 for your partner’s {0} pay
 
+result.title = Help you could get with your childcare costs
+result.heading = Help you could get with your childcare costs
 result.eligible.heading = You are eligible for:
 result.heading.not.eligible = You are not eligible for any help with your childcare costs
 result.guidance = You told the calculator that you have children, with childcare costs of £. You live on your own and only you are currently in paid work. You work hours and your partner works hours a week.

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/ResultViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/ResultViewSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.views.html.result
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 
 class ResultViewSpec extends ViewBehaviours with ViewSpecBase {
-  
+
   "Result view" must {
     val view = () => result(frontendAppConfig,
       ResultsViewModel(tc = Some(400)),
@@ -39,12 +39,12 @@ class ResultViewSpec extends ViewBehaviours with ViewSpecBase {
 
     "display the correct browser title" in {
       val doc = asDocument(view())
-      assertEqualsValue(doc, "title", messagesApi(s"result.single.eligibility.heading")+" - "+messagesApi("site.service_name")+" - GOV.UK")
+      assertEqualsValue(doc, "title", messagesApi(s"result.title")+" - "+messagesApi("site.service_name")+" - GOV.UK")
     }
 
     "display the correct page title" in {
       val doc = asDocument(view())
-      assertPageTitleEqualsMessage(doc, s"result.single.eligibility.heading")
+      assertPageTitleEqualsMessage(doc, s"result.title")
     }
 
     "display a beta banner" in {
@@ -94,7 +94,7 @@ class ResultViewSpec extends ViewBehaviours with ViewSpecBase {
       val model = ResultsViewModel()
       val view = asDocument(result(frontendAppConfig, model, new Utils)(fakeRequest, messages))
 
-      assertContainsMessages(view, messages("result.heading.not.eligible"))
+      assertContainsMessages(view, messages("result.title"))
       assertNotContainsText(view, messages("result.more.info.title"))
       assertNotContainsText(view, messages("result.more.info.para"))
       assertNotContainsText(view, messages("result.read.more.button"))

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/ResultViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/ResultViewSpec.scala
@@ -22,42 +22,13 @@ import uk.gov.hmrc.childcarecalculatorfrontend.views.behaviours.ViewBehaviours
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.result
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes._
 
-class ResultViewSpec extends ViewBehaviours with ViewSpecBase {
-
+class ResultViewSpec extends ViewBehaviours {
+  
   "Result view" must {
-    val view = () => result(frontendAppConfig,
-      ResultsViewModel(tc = Some(400)),
-      new Utils)(fakeRequest, messages)
 
-
-    "have the correct banner title" in {
-      val doc = asDocument(view())
-      val nav = doc.getElementById("proposition-menu")
-      val span = nav.children.first
-      span.text mustBe messagesApi("site.service_name")
-    }
-
-    "display the correct browser title" in {
-      val doc = asDocument(view())
-      assertEqualsValue(doc, "title", messagesApi(s"result.title")+" - "+messagesApi("site.service_name")+" - GOV.UK")
-    }
-
-    "display the correct page title" in {
-      val doc = asDocument(view())
-      assertPageTitleEqualsMessage(doc, s"result.title")
-    }
-
-    "display a beta banner" in {
-      val doc = asDocument(view())
-      assertRenderedByCssSelector(doc, ".beta-banner")
-    }
-
-    "not display HMRC branding" in {
-      val doc = asDocument(view())
-      assertNotRenderedByCssSelector(doc, ".organisation-logo")
-    }
-
-
+    behave like normalPage(() => result(frontendAppConfig,
+                                        ResultsViewModel(tc = Some(400)),
+                                        new Utils)(fakeRequest, messages), "result")
 
     "Contain results" when {
       "We have introductory paragraph" in {


### PR DESCRIPTION
For some reason the title of this page was changed over the xmas break. It should not indicate how many schemes you can get in the title as this amongst other things would imply that you could get all of them which is not correct. So have moved this logic to its correct place and put a visuallyhidden class on it as it is mainly for screen readers that cannot see the colour. And then added the new title and heading to the page.

This has also been picked up by Nyree one of the TFC Lawyers.

Test page also changed to reflect this change.