### PR TITLE
CCALC-3857: Add date validation to statutory pay

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/Mappings.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/Mappings.scala
@@ -17,12 +17,9 @@
 package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
 import org.joda.time.LocalDate
-import play.api.data.{FieldMapping, FormError}
+import play.api.data.FieldMapping
 import play.api.data.Forms.of
-import play.api.data.format.Formatter
 import play.api.data.validation.{Constraint, Invalid, Valid}
-
-import scala.util.control.Exception.nonFatalCatch
 
 trait Mappings extends Formatters {
 
@@ -78,6 +75,14 @@ trait Mappings extends Formatters {
   protected def before(date: LocalDate, errorKey: String, errorArgs: Any*): Constraint[LocalDate] =
     Constraint {
       case d if d.isBefore(date) =>
+        Valid
+      case _ =>
+        Invalid(errorKey, errorArgs: _*)
+    }
+
+  protected def after(date: LocalDate, errorKey: String, errorArgs: Any*): Constraint[LocalDate] =
+    Constraint {
+      case d if d.isAfter(date) =>
         Valid
       case _ =>
         Invalid(errorKey, errorArgs: _*)

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryStartDateForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryStartDateForm.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.forms
 import org.joda.time.LocalDate
 import play.api.data.{Form, FormError}
 import play.api.data.Forms._
+import uk.gov.hmrc.time.TaxYearResolver
 
 object PartnerStatutoryStartDateForm extends FormErrorHelper {
 
@@ -33,6 +34,7 @@ object PartnerStatutoryStartDateForm extends FormErrorHelper {
         "year" -> int(requiredKey, invalidKey, statutoryType)
       )
         .verifying(before(LocalDate.now.plusDays(1), "partnerStatutoryStartDate.error.past", statutoryType))
+        .verifying(after(TaxYearResolver.startOfCurrentTaxYear.minusYears(2).minusDays(1), "partnerStatutoryStartDate.error.past-over-2-years", statutoryType, TaxYearResolver.startOfCurrentTaxYear.getYear.toString()))
         .replaceError(FormError("", "error.invalidDate", statutoryType), FormError("", invalidKey, Seq(statutoryType)))
         .replaceError(FormError("day", requiredKey, statutoryType), FormError("", requiredKey, Seq(statutoryType)))
         .replaceError(FormError("month", requiredKey, statutoryType), FormError("", requiredKey, Seq(statutoryType)))

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryStartDateForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourStatutoryStartDateForm.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.childcarecalculatorfrontend.forms
 import org.joda.time.LocalDate
 import play.api.data.{Form, FormError}
 import play.api.data.Forms._
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.TaxYearInfo
+import uk.gov.hmrc.time.TaxYearResolver
 
 object YourStatutoryStartDateForm extends FormErrorHelper {
 
@@ -33,6 +35,7 @@ object YourStatutoryStartDateForm extends FormErrorHelper {
         "year" -> int(requiredKey, invalidKey, statutoryType)
       )
         .verifying(before(LocalDate.now.plusDays(1), "yourStatutoryStartDate.error.past", statutoryType))
+        .verifying(after(TaxYearResolver.startOfCurrentTaxYear.minusYears(2).minusDays(1), "yourStatutoryStartDate.error.past-over-2-years", statutoryType, TaxYearResolver.startOfCurrentTaxYear.getYear.toString()))
         .replaceError(FormError("", "error.invalidDate", statutoryType), FormError("", invalidKey, Seq(statutoryType)))
         .replaceError(FormError("day", requiredKey, statutoryType), FormError("", requiredKey, Seq(statutoryType)))
         .replaceError(FormError("month", requiredKey, statutoryType), FormError("", requiredKey, Seq(statutoryType)))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1167,6 +1167,7 @@ yourStatutoryStartDate.error.invalid = You must enter correct date
 yourStatutoryStartDate.error.past = Date your {0} pay started must be in the past
 yourStatutoryStartDate.hint = For example, 31 1 2017
 yourStatutoryStartDate.checkYourAnswersLabel = yourStatutoryStartDate
+yourStatutoryStartDate.error.past-over-2-years = Date your {0} pay started cannot be more than 2 years before 6 April {1}
 
 partnerStatutoryStartDate.title = When did your partner’s {0} pay start?
 partnerStatutoryStartDate.heading = When did your partner’s {0} pay start?
@@ -1175,6 +1176,7 @@ partnerStatutoryStartDate.error.invalid = You must enter correct date
 partnerStatutoryStartDate.error.past = Date your partner’s {0} pay started must be in the past
 partnerStatutoryStartDate.hint = For example, 31 1 2017
 partnerStatutoryStartDate.checkYourAnswersLabel = partnerStatutoryStartDate
+partnerStatutoryStartDate.error.past-over-2-years = Date your partner’s {0} pay started cannot be more than 2 years before 6 April {1}
 
 yourStatutoryPayBeforeTax.title = Was this {0} pay less than £100 a week before tax?
 yourStatutoryPayBeforeTax.heading = Was this {0} pay less than £100 a week before tax?
@@ -1185,6 +1187,7 @@ partnerStatutoryPayBeforeTax.title = Was this {0} pay more than £100 a week bef
 partnerStatutoryPayBeforeTax.heading = Was this {0} pay more than £100 a week before tax?
 partnerStatutoryPayBeforeTax.checkYourAnswersLabel = Was this {0} pay more than £100 a week before tax?
 partnerStatutoryPayBeforeTax.error = Select yes if this {0} pay was less than £100 before tax
+
 
 yourStatutoryPayPerWeek.title = How much {0} pay did you get a week before tax?
 yourStatutoryPayPerWeek.heading = How much {0} pay did you get a week before tax?

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryStartDateFormSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/forms/PartnerStatutoryStartDateFormSpec.scala
@@ -17,8 +17,11 @@
 package uk.gov.hmrc.childcarecalculatorfrontend.forms
 
 import org.joda.time.LocalDate
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.time.TaxYearResolver
+import org.mockito.Mockito._
 
-class PartnerStatutoryStartDateFormSpec extends FormSpec {
+class PartnerStatutoryStartDateFormSpec extends FormSpec with MockitoSugar {
 
   val statutoryType = "maternity"
 
@@ -29,7 +32,6 @@ class PartnerStatutoryStartDateFormSpec extends FormSpec {
   )
 
   val form = PartnerStatutoryStartDateForm(statutoryType)
-
 
   "PartnerStatutoryStartDate Form" must {
 
@@ -73,5 +75,37 @@ class PartnerStatutoryStartDateFormSpec extends FormSpec {
       val expectedError = error("date", "partnerStatutoryStartDate.error.past", statutoryType)
       checkForError(form, data, expectedError)
     }
+
+    "fail to bind when the date is more than 2 years and 1 day before 6th April 2017 " in {
+      val mockTaxYearInfo = mock[TaxYearResolver]
+      val taxYearStart = new LocalDate(2017: Int, 4: Int, 5: Int)
+
+      when(mockTaxYearInfo.startOfCurrentTaxYear) thenReturn taxYearStart
+
+      val data = Map(
+        "date.day" -> "5",
+        "date.month" -> "4",
+        "date.year" -> "2015"
+      )
+
+      val expectedError = error("date", "partnerStatutoryStartDate.error.past-over-2-years", statutoryType, "2017")
+      checkForError(form, data, expectedError)
+    }
+
+    "successfully bind when the date is exactly 2 years before 6th April 2017" in {
+      val mockTaxYearInfo = mock[TaxYearResolver]
+      val taxYearStart = new LocalDate(2017: Int, 4: Int, 6: Int)
+
+      when(mockTaxYearInfo.startOfCurrentTaxYear) thenReturn taxYearStart
+
+      val data: Map[String, String] = Map(
+        "date.day" -> "6",
+        "date.month" -> "4",
+        "date.year" -> "2015"
+      )
+
+      form.bind(data).get shouldEqual new LocalDate(2015: Int, 4: Int, 6: Int)
+    }
+
   }
 }


### PR DESCRIPTION
Added validation to ensure statutory date entered is within 2 years of the start of the current tax year. Needs manual QA before merging