### PR TITLE
CCALC-3923: Update content on results page

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/freeHoursResult.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/freeHoursResult.scala.html
@@ -27,7 +27,9 @@
 @(appConfig: FrontendAppConfig,
         location: Location.Value,
         eligibility: Eligibility,
-        answerSections: Seq[Section], paidEmployment: Boolean, livingWithPartner: Boolean)(implicit request: Request[_], messages: Messages)
+        paidEmployment: Boolean,
+        livingWithPartner: Boolean,
+        approvedProvider: Boolean)(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("freeHoursResult.title"),
@@ -72,7 +74,7 @@
 
                     <!-- Note for dev. There is content ready in the messages file for the option when you have said no to approved childcare its freeHoursResult.info.OtherSchemes.approved.text etc -->
 
-                    @if(paidEmployment) {
+                    @if(paidEmployment || !approvedProvider) {
                         <p>@messages("freeHoursResult.info.OtherSchemes.text")</p>
                     } else {
                         <p>@messages("freeHoursResult.info.OtherSchemes.paidwork.text")</p>
@@ -94,12 +96,21 @@
             <a id="free-hours-results-childCare-cost-link" href="@routes.ChildcareCostsController.onPageLoad(NormalMode)">@messages(s"freeHoursResult.toBeEligible.info2.link.text")</a>
             @messages("freeHoursResult.toBeEligible.info2.end")</p>
     } else {
-        <p>@messages("freeHoursResult.toBeEligible.info3.start")
+
+        @if(!approvedProvider) {
+            <p>@messages("freeHoursResult.toBeEligible.info2b.start")
+            <a id="free-hours-results-childCare-cost-link" href="@routes.ApprovedProviderController.onPageLoad(NormalMode)">@messages(s"freeHoursResult.toBeEligible.info2b.link.text")</a>
+                @messages("freeHoursResult.toBeEligible.info2b.end")
+                </p>
+        } else {
+            <p>@messages("freeHoursResult.toBeEligible.info3.start")
             @if(livingWithPartner){
                 <a id="free-hours-results-childCare-cost-link" href="@routes.WhoIsInPaidEmploymentController.onPageLoad(NormalMode)">@messages(s"freeHoursResult.toBeEligible.info3.link.text")</a>
             } else {
                 <a id="free-hours-results-childCare-cost-link" href="@routes.AreYouInPaidWorkController.onPageLoad(NormalMode)">@messages(s"freeHoursResult.toBeEligible.info3.link.text")</a>
             }
-            @messages("freeHoursResult.toBeEligible.info3.end")</p>
+            @messages("freeHoursResult.toBeEligible.info3.end")
+        </p>
+        }
     }
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/FreeHoursResultControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/FreeHoursResultControllerSpec.scala
@@ -64,7 +64,7 @@ class FreeHoursResultControllerSpec extends ControllerSpecBase {
        val result = controller(getRelevantData).onPageLoad()(fakeRequest)
 
        status(result) mustBe OK
-       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,getAnswers(answers),false, true)(fakeRequest, messages).toString
+       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,false, true, false)(fakeRequest, messages).toString
      }
 
      "your partner works" in {
@@ -82,7 +82,7 @@ class FreeHoursResultControllerSpec extends ControllerSpecBase {
        val result = controller(getRelevantData).onPageLoad()(fakeRequest)
 
        status(result) mustBe OK
-       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,getAnswers(answers),true, true)(fakeRequest, messages).toString
+       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,true, true, false)(fakeRequest, messages).toString
      }
 
      "you live on your own and don't work" in {
@@ -99,7 +99,7 @@ class FreeHoursResultControllerSpec extends ControllerSpecBase {
        val result = controller(getRelevantData).onPageLoad()(fakeRequest)
 
        status(result) mustBe OK
-       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,getAnswers(answers),false, false)(fakeRequest, messages).toString
+       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,false, false, false)(fakeRequest, messages).toString
      }
 
      "you live on your own and work" in {
@@ -117,7 +117,7 @@ class FreeHoursResultControllerSpec extends ControllerSpecBase {
        val result = controller(getRelevantData).onPageLoad()(fakeRequest)
 
        status(result) mustBe OK
-       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,getAnswers(answers),true, false)(fakeRequest, messages).toString
+       contentAsString(result) mustBe freeHoursResult(frontendAppConfig,location,eligibility,true, false, false)(fakeRequest, messages).toString
      }
    }
 
@@ -136,17 +136,6 @@ class FreeHoursResultControllerSpec extends ControllerSpecBase {
        await(controller(getRelevantData).onPageLoad()(fakeRequest))
      }
    }
-  }
-
-  private def getAnswers(answers: UserAnswers) = {
-    val checkYourAnswersHelper = new CheckYourAnswersHelper(answers)
-    val sections = Seq(AnswerSection(None, Seq(
-      checkYourAnswersHelper.location,
-      checkYourAnswersHelper.childAgedTwo,
-      checkYourAnswersHelper.childAgedThreeOrFour,
-      checkYourAnswersHelper.childcareCosts
-    ).flatten))
-    sections
   }
 
   val freeHours = new FreeHours()

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/FreeHoursResultViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/FreeHoursResultViewSpec.scala
@@ -27,17 +27,25 @@ class FreeHoursResultViewSpec extends ViewBehaviours {
 
   val messageKeyPrefix = "freeHoursResult"
 
-  def createView = () => freeHoursResult(frontendAppConfig, Location.ENGLAND, NotEligible, Seq(),false, false)(fakeRequest, messages)
+  private def createView = () => freeHoursResult(frontendAppConfig, Location.ENGLAND, NotEligible,
+    paidEmployment = false,
+    livingWithPartner = false,
+    approvedProvider = false)(fakeRequest, messages)
 
-  def createViewWithAnswers = (location: Location.Value,
-                               eligibility:Eligibility,
-                               answerSections: Seq[Section]) => freeHoursResult(frontendAppConfig,
-                                                                                location,
-                                                                                eligibility,
-                                                                                answerSections,true, false)(fakeRequest, messages)
+  private def createViewWithAnswers = (
+                                        location: Location.Value,
+                                        eligibility: Eligibility,
+                                        paidEmployment: Boolean,
+                                        livingWithPartner: Boolean,
+                                        approvedProvider: Boolean) => freeHoursResult(frontendAppConfig,
+    location,
+    eligibility,
+    paidEmployment,
+    livingWithPartner,
+    approvedProvider)(fakeRequest, messages)
 
   "FreeHoursResult view" must {
-      behave like normalPage(createView,
+    behave like normalPage(createView,
       messageKeyPrefix,
       "toBeEligible.heading")
 
@@ -46,16 +54,27 @@ class FreeHoursResultViewSpec extends ViewBehaviours {
 
   "FreeHoursResult view" when {
     "rendered" must {
+
+      "contain correct guidance when not eligible because you don't have a child under 5 and you're not with an approved provider" in {
+
+        val doc = asDocument(createViewWithAnswers(Location.ENGLAND, NotEligible, false, false, false))
+
+        assertContainsText(doc, messagesApi("freeHoursResult.info.freHours"))
+        assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.info1.start"))
+        assertContainsText(doc, messagesApi("freeHoursResult.info.OtherSchemes"))
+        assertContainsText(doc, messagesApi("freeHoursResult.info.OtherSchemes.text"))
+        assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.heading"))
+        assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.info2b.start"))
+        assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.info2b.end"))
+
+        val approvedProvierLink: Element = doc.getElementById("free-hours-results-childCare-cost-link")
+        approvedProvierLink.attr("href") mustBe routes.ApprovedProviderController.onPageLoad(NormalMode).url
+        approvedProvierLink.text mustBe messagesApi("freeHoursResult.toBeEligible.info2b.link.text")
+      }
+
       "contain correct guidance when not eligible for location other than northern-ireland" in {
 
-        val answerRow = AnswerRow("location.checkYourAnswersLabel",
-          "location.england",
-          true,
-          routes.LocationController.onPageLoad(CheckMode).url)
-
-        val answerSections = Seq(AnswerSection(None, Seq(answerRow)))
-
-        val doc = asDocument(createViewWithAnswers(Location.ENGLAND, NotEligible, answerSections))
+        val doc = asDocument(createViewWithAnswers(Location.ENGLAND, NotEligible, true, false, false))
 
         assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.heading"))
 
@@ -70,14 +89,7 @@ class FreeHoursResultViewSpec extends ViewBehaviours {
 
       "contain correct guidance when not eligible for location northern-ireland" in {
 
-        val answerRow = AnswerRow("location.checkYourAnswersLabel",
-          "location.northern-ireland",
-          true,
-          routes.LocationController.onPageLoad(CheckMode).url)
-
-        val answerSections = Seq(AnswerSection(None, Seq(answerRow)))
-
-        val doc = asDocument(createViewWithAnswers(Location.NORTHERN_IRELAND, NotEligible, answerSections))
+        val doc = asDocument(createViewWithAnswers(Location.NORTHERN_IRELAND, NotEligible, true, false, false))
 
         assertContainsText(doc, messagesApi("freeHoursResult.toBeEligible.heading"))
 
@@ -91,21 +103,21 @@ class FreeHoursResultViewSpec extends ViewBehaviours {
       }
 
       "eligible for 16 free hours for scotland and not eligible for other schemes" in {
-        val doc = asDocument(createViewWithAnswers(Location.SCOTLAND, Eligible, Seq()))
+        val doc = asDocument(createViewWithAnswers(Location.SCOTLAND, Eligible, true, false, false))
 
         assertContainsText(doc, messagesApi("freeHoursResult.info.entitled.scotland"))
         assertContainsText(doc, messagesApi("freeHoursResult.partialEligible.guidance.scotland"))
       }
 
       "eligible for 10 free hours for wales and not eligible for other schemes" in {
-        val doc = asDocument(createViewWithAnswers(Location.WALES, Eligible, Seq()))
+        val doc = asDocument(createViewWithAnswers(Location.WALES, Eligible, true, false, false))
 
         assertContainsText(doc, messagesApi("freeHoursResult.info.entitled.wales"))
         assertContainsText(doc, messagesApi("freeHoursResult.partialEligible.guidance.wales"))
       }
 
       "eligible for 12.5 free hours for northern-ireland and not eligible for other schemes" in {
-        val doc = asDocument(createViewWithAnswers(Location.NORTHERN_IRELAND, Eligible, Seq()))
+        val doc = asDocument(createViewWithAnswers(Location.NORTHERN_IRELAND, Eligible, true, false, false))
 
         assertContainsText(doc, messagesApi("freeHoursResult.info.entitled.northern-ireland"))
         assertContainsText(doc, messagesApi("freeHoursResult.partialEligible.guidance.northern-ireland"))


### PR DESCRIPTION
Updated free hours results page to display correct content when user doesn't have approved childcare costs.

Refactored to remove unused sections argument