### PR TITLE
CCALC-3929: Fix issue with not displaying childcare-vouchers option

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/MaxFreeHoursInfoController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/MaxFreeHoursInfoController.scala
@@ -26,8 +26,8 @@ import uk.gov.hmrc.childcarecalculatorfrontend.models.schemes.{EmploymentSupport
 import uk.gov.hmrc.childcarecalculatorfrontend.models.{YesNoNotYetEnum, YesNoUnsureEnum}
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.childcarecalculatorfrontend.views.html.maxFreeHoursInfo
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 @Singleton
 class MaxFreeHoursInfoController @Inject()(val appConfig: FrontendAppConfig,
@@ -49,9 +49,13 @@ class MaxFreeHoursInfoController @Inject()(val appConfig: FrontendAppConfig,
   }
 
   private def getESCEligibility(answers: UserAnswers): Boolean = {
+
     val No = YesNoUnsureEnum.NO.toString
 
-    val hasParentChildcareCosts: Boolean = answers.childcareCosts.contains(YesNoNotYetEnum.YES.toString)
+    val hasParentChildcareCosts: Boolean = answers.childcareCosts.fold(false) {
+      _ != YesNoNotYetEnum.NO.toString
+    }
+
     val hasPartnerChildcareVouchers = answers.partnerChildcareVouchers.fold(false)(x => !x.equals(No))
     val hasParentChildcareVouchers = answers.yourChildcareVouchers.fold(false)(x => !x.equals(No))
 
@@ -61,12 +65,12 @@ class MaxFreeHoursInfoController @Inject()(val appConfig: FrontendAppConfig,
 
     if (hasPartner) {
       whoInPaidEmployment match {
-        case  Some(You) => hasParentChildcareCosts && hasParentChildcareVouchers
+        case Some(You) => hasParentChildcareCosts && hasParentChildcareVouchers
         case Some(Partner) => hasParentChildcareCosts && hasPartnerChildcareVouchers
         case Some(_) => hasParentChildcareCosts && bothChildcareVouchers.contains(Both)
         case _ => false
       }
-    }else{
+    } else {
       hasParentChildcareCosts && hasParentChildcareVouchers
     }
   }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/views/MaxFreeHoursInfoViewSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/views/MaxFreeHoursInfoViewSpec.scala
@@ -30,7 +30,7 @@ class MaxFreeHoursInfoViewSpec extends ViewBehaviours {
 
     behave like normalPage(view, messageKeyPrefix, "could.get.max.hours", "info", "info.link", "info.link.url", "info.part2", "still.to.check")
 
-    "display correct message when only eligible for tax free chjldcare" in {
+    "display correct message when only eligible for tax free childcare" in {
       val view = maxFreeHoursInfo(frontendAppConfig, Eligible, false, NotEligible) (fakeRequest, messages)
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tfc"))
 
@@ -39,11 +39,17 @@ class MaxFreeHoursInfoViewSpec extends ViewBehaviours {
     "display the correct message when only eligible for childcare vouchers" in {
       val view = maxFreeHoursInfo(frontendAppConfig, NotEligible, true, NotEligible) (fakeRequest, messages)
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.vouchers"))
+      assertNotContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tax_credits"))
+      assertNotContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tfc"))
     }
 
     "display the correct message when only eligible for tax credits" in {
       val view = maxFreeHoursInfo(frontendAppConfig, NotEligible, false, Eligible) (fakeRequest, messages)
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tax_credits"))
+      assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.still.to.check"))
+      assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.give.more.info"))
+      assertNotContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tfc"))
+      assertNotContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.vouchers"))
     }
 
     "display correct message when only eligible for tax free childcare, childcare vouchers, tax credits " in {
@@ -51,7 +57,9 @@ class MaxFreeHoursInfoViewSpec extends ViewBehaviours {
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tfc"))
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.vouchers"))
       assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.li.tax_credits"))
-
+      assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.still.to.check"))
+      assertContainsText(asDocument(view), messagesApi(s"$messageKeyPrefix.give.more.info"))
     }
   }
+
 }


### PR DESCRIPTION
30 hours info page now shows childcare-vouchers if user selects _not yet but maybe in the future_ for childcare costs.