### PR TITLE
DL-1538 Decouple LocalDate.now unit test dependency

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigator.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigator.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.childcarecalculatorfrontend.navigation
 
 import javax.inject.Inject
-
 import org.joda.time.LocalDate
 import play.api.Logger
 import play.api.mvc.Call
@@ -25,11 +24,10 @@ import uk.gov.hmrc.childcarecalculatorfrontend.SubNavigator
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.routes
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers._
 import uk.gov.hmrc.childcarecalculatorfrontend.models.{AboutYourChild, NormalMode}
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.{UserAnswers, Utils}
-import uk.gov.hmrc.childcarecalculatorfrontend.utils.{SessionExpiredRouter, UserAnswers}
+import uk.gov.hmrc.childcarecalculatorfrontend.utils.{DateTimeUtils, SessionExpiredRouter, UserAnswers, Utils}
 
 
-class ChildcareNavigator @Inject() (utils: Utils) extends SubNavigator {
+class ChildcareNavigator @Inject() (utils: Utils) extends SubNavigator with DateTimeUtils {
 
   override protected lazy val routeMap: PartialFunction[Identifier, UserAnswers => Call] = {
     case NoOfChildrenId => _ => routes.AboutYourChildController.onPageLoad(NormalMode, 0)
@@ -64,14 +62,14 @@ class ChildcareNavigator @Inject() (utils: Utils) extends SubNavigator {
     }
   }.getOrElse(SessionExpiredRouter.route(getClass.getName,"aboutYourChildRoutes",Some(answers)))
 
-  private def childApprovedEducationRoutes(id: Int)(answers: UserAnswers): Call = {
+  private def     childApprovedEducationRoutes(id: Int)(answers: UserAnswers): Call = {
 
     def next(i: Int, childrenOver16: Map[Int, AboutYourChild]): Option[Int] = {
       val ints: Seq[Int] = childrenOver16.keys.toSeq
       ints.lift(ints.indexOf(i) + 1)
     }
 
-    def childIsOver19(dob: LocalDate) = dob.isBefore(LocalDate.now.minusYears(19))
+    def childIsOver19(dob: LocalDate) = dob.isBefore(now.minusYears(19))
 
     for {
       childrenOver16    <- answers.childrenOver16

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/DateTimeUtils.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/DateTimeUtils.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.childcarecalculatorfrontend.utils
+
+import org.joda.time.LocalDate
+
+trait DateTimeUtils {
+  def now: LocalDate = LocalDate.now()
+}

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswers.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswers.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.identifiers._
 import uk.gov.hmrc.childcarecalculatorfrontend.models._
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-class UserAnswers(val cacheMap: CacheMap) extends MapFormats {
+class UserAnswers(val cacheMap: CacheMap) extends MapFormats with DateTimeUtils {
   def bothGetSameIncomePreviousYear: Option[Boolean] = cacheMap.getEntry[Boolean](BothGetSameIncomePreviousYearId.toString)
 
   def youGetSameIncomePreviousYear: Option[Boolean] = cacheMap.getEntry[Boolean](YouGetSameIncomePreviousYearId.toString)
@@ -322,8 +322,8 @@ class UserAnswers(val cacheMap: CacheMap) extends MapFormats {
     children.map {
       children16OrOlder =>
         children16OrOlder.filter {
-          case (_, model) => model.dob.plusYears(16).isAfter(LocalDate.parse(s"${LocalDate.now().getYear-1}-8-31")) &&
-            model.dob.plusYears(16).isBefore(LocalDate.parse(s"${LocalDate.now().getYear}-09-1"))
+          case (_, model) => model.dob.plusYears(16).isAfter(LocalDate.parse(s"${now.getYear-1}-8-31")) &&
+            model.dob.plusYears(16).isBefore(LocalDate.parse(s"${now.getYear}-09-1"))
         }
     }
   }
@@ -332,9 +332,7 @@ class UserAnswers(val cacheMap: CacheMap) extends MapFormats {
     aboutYourChild.map {
       children =>
         children.filter {
-          case (_, model) => {
-            model.dob.isBefore(LocalDate.now.minusYears(16))
-          }
+          case (_, model) =>model.dob.isBefore(now.minusYears(16))
         }
     }
   }
@@ -348,9 +346,8 @@ class UserAnswers(val cacheMap: CacheMap) extends MapFormats {
     (childrenIdsForAgeExactly16AndDisabled ++childrenBelow16).sorted
   }
 
-  def childrenBelow16:List[Int] = {
-  aboutYourChild.getOrElse(Map()).filter(_._2.dob.isAfter(LocalDate.now.minusYears(16))).keys.toList
-  }
+  def childrenBelow16:List[Int] =
+    aboutYourChild.getOrElse(Map()).filter(_._2.dob.isAfter(now.minusYears(16))).keys.toList
 
   def childrenIdsForAgeExactly16AndDisabled: List[Int] = {
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include "common.conf"
+play.http.secret.key="yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+
 include "validTaxCodes.conf"
 include "nmw.conf"
 
@@ -20,9 +21,6 @@ include "nmw.conf"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-
-# this key is for local development only!
-play.http.secret.key="yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 
 # this key is for local development only!
 cookie.encryption.key="gvBoGdgzqG1AarzF1LY0zQ=="

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -10,22 +10,25 @@ object FrontendBuild extends Build with MicroService {
 }
 
 private object AppDependencies {
-  private val playHealthVersion = "3.10.0-play-26"
-  private val bootstrapPlayVersion = "0.36.0"
+  private val playHealthVersion = "3.12.0-play-26"
+  private val bootstrapPlayVersion = "0.37.0"
   private val logbackJsonLoggerVersion = "4.2.0"
   private val govukTemplateVersion = "5.27.0-play-26"
-  private val playUiVersion = "7.31.0-play-26"
-  private val hmrcTestVersion = "3.4.0-play-26"
+  private val playUiVersion = "7.33.0-play-26"
+  private val hmrcTestVersion = "3.6.0-play-26"
   private val scalaTestVersion = "3.0.5"
   private val scalaCheckVersion = "1.13.4"
   private val scalaTestPlusPlayVersion = "2.0.1"
   private val pegdownVersion = "1.6.0"
   private val mockitoCoreVersion = "2.23.4"
-  private val httpCachingClientVersion = "8.0.0"
-  private val playReactivemongoVersion = "7.14.0-play-26"
+  private val httpCachingClientVersion = "8.1.0"
+  private val playReactivemongoVersion = "7.16.0-play-26"
   private val playConditionalFormMappingVersion = "0.2.0"
   private val playLanguageVersion = "3.4.0"
   private val taxYearVersion = "0.4.0"
+  private val playJavaVersion = "2.6.12"
+  private val httpVerbsVersion = "9.4.0-play-26"
+
   private val hmrc = "uk.gov.hmrc"
   private val typesafe = "com.typesafe.play"
 
@@ -41,6 +44,8 @@ private object AppDependencies {
     hmrc %% "bootstrap-play-26" % bootstrapPlayVersion,
     hmrc %% "play-language" % playLanguageVersion,
     hmrc %% "tax-year" % taxYearVersion,
+    hmrc %% "http-verbs" % httpVerbsVersion,
+    typesafe %% "play-java" % playJavaVersion,
     typesafe %% "play-json" % "2.6.13",
     typesafe %% "play-json-joda" % "2.6.13"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.14.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
 
@@ -22,10 +22,12 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.3.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.16.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/DataGenerator.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/DataGenerator.scala
@@ -36,16 +36,28 @@ case class DataGenerator(sample: CacheMap) extends SubCascadeUpsert{
 }
 
 object DataGenerator {
-  val over19 = LocalDate.now.minusYears(19).minusDays(1)
-  val testBeforeAugust: Int = LocalDate.now.minusYears(16).getYear
-  val exact16 = new LocalDate(testBeforeAugust, 6, 1)
-  val over16 = if (LocalDate.now().getMonthOfYear <= 8) LocalDate.now.minusYears(17) else LocalDate.now.minusYears(16)
-  val exact15 = LocalDate.now.minusYears(15).plusMonths(1)
-  val over16WithBirthdayBefore31stOfAugust = if (LocalDate.now().getMonthOfYear > 8) LocalDate.parse(s"${LocalDate.now.minusYears(16).getYear}-07-31")
-  else LocalDate.now.minusYears(16)
+  val ageOf19YearsAgo: LocalDate => LocalDate = (date : LocalDate) =>
+    date.minusYears(19).minusDays(1)
+  val ageOf16WithBirthdayBefore31stAugust: LocalDate => LocalDate = (date : LocalDate) =>
+    if (date.getMonthOfYear > 8) {
+      LocalDate.parse(s"${date.minusYears(16).getYear}-07-31")
+    } else {
+      date.minusYears(16)
+    }
+  val ageOfOver16Relative: LocalDate => LocalDate = (date : LocalDate) =>
+    if (date.getMonthOfYear <= 8) {
+      date.minusYears(17)
+    } else {
+      date.minusYears(16)
+    }
+  val ageUnder16Relative: LocalDate => LocalDate = (date : LocalDate) =>
+    date.minusYears(1)
+  val ageExactly16Relative: LocalDate => LocalDate = (date : LocalDate) =>
+    new LocalDate(date.minusYears(16).getYear, 6, 1)
+  val ageExactly15Relative: LocalDate => LocalDate = (date : LocalDate) =>
+    new LocalDate(date.minusYears(15).getYear, 6, 1)
 
-  val under16 = LocalDate.now
-  val childStartEducationDate = new LocalDate(2017, 2, 1)
+  private val childStartEducationDate = new LocalDate(2017, 2, 1)
 
   lazy val disabilityBenefits: String = DisabilityBenefits.DISABILITY_BENEFITS.toString
   lazy val higherRateDisabilityBenefits: String = DisabilityBenefits.HIGHER_DISABILITY_BENEFITS.toString
@@ -53,14 +65,17 @@ object DataGenerator {
   lazy val weekly: String = ChildcarePayFrequency.WEEKLY.toString
   lazy val monthly: String = ChildcarePayFrequency.MONTHLY.toString
 
+  private val sampleDate = LocalDate.parse("2019-01-01")
+
   val sample = new CacheMap("id", Map(
     NoOfChildrenId.toString -> JsNumber(5),
     AboutYourChildId.toString -> Json.obj(
-      "0" -> Json.toJson(AboutYourChild("Foo", over19)),
-      "1" -> Json.toJson(AboutYourChild("Bar", over16)),
-      "2" -> Json.toJson(AboutYourChild("Quux", exact15)),
-      "3" -> Json.toJson(AboutYourChild("Baz", under16)),
-      "4" -> Json.toJson(AboutYourChild("Raz", under16))),
+      "0" -> Json.toJson(AboutYourChild("Foo", sampleDate)),
+      "1" -> Json.toJson(AboutYourChild("Bar", sampleDate)),
+      "2" -> Json.toJson(AboutYourChild("Quux", sampleDate)),
+      "3" -> Json.toJson(AboutYourChild("Baz", sampleDate)),
+      "4" -> Json.toJson(AboutYourChild("Raz", sampleDate))
+    ),
     ChildApprovedEducationId.toString -> Json.obj(
       "0" -> true,
       "1" -> true

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/actions/FakeDataRetrievalAction.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions
 
+import org.joda.time.LocalDate
 import play.api.Application
-import play.api.mvc._
+import play.api.mvc.{Request, _}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.requests.OptionalDataRequest
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.UserAnswers
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -25,13 +26,19 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeDataRetrievalAction(cacheMapToReturn: Option[CacheMap])(implicit app: Application) extends DataRetrievalAction {
+class FakeDataRetrievalAction(cacheMapToReturn: Option[CacheMap], timeReplacement: Option[LocalDate] = None)
+                             (implicit app: Application) extends DataRetrievalAction {
 
   override def executionContext: ExecutionContext = global
-  override def parser: BodyParser[AnyContent] = app.injector.instanceOf[MessagesControllerComponents].parsers.defaultBodyParser
+  override def parser: BodyParser[AnyContent]     = app.injector.instanceOf[MessagesControllerComponents].parsers.defaultBodyParser
 
-  override protected def transform[A](request: Request[A]): Future[OptionalDataRequest[A]] = cacheMapToReturn match {
-    case None => Future(OptionalDataRequest(request, "id", None))
-    case Some(cacheMap)=> Future(OptionalDataRequest(request, "id", Some(new UserAnswers(cacheMap))))
+  override protected def transform[A](request: Request[A]): Future[OptionalDataRequest[A]] = {
+    val userAnswers: Option[UserAnswers] = cacheMapToReturn map {
+      new UserAnswers(_) {
+        override def now: LocalDate = timeReplacement.getOrElse(LocalDate.now())
+      }
+    }
+
+    Future(OptionalDataRequest(request, "id", userAnswers))
   }
 }


### PR DESCRIPTION
# DL-1538 Decouple LocalDate.now unit test dependency

**Unit test improvement**

* Decoupled LocalDate.now dependencies from several unit tests. This reduces the chance of unit tests intermittently failing due to them relying the LocalDate being within in a specific date set.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
