### PR TITLE
DL-2044 Suppression of tax credit information

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ResultController.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ResultController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.childcarecalculatorfrontend.controllers
 
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.MoreInfoService
 import uk.gov.hmrc.childcarecalculatorfrontend.FrontendAppConfig
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.DataCacheConnector
@@ -46,14 +46,12 @@ class ResultController @Inject()(val appConfig: FrontendAppConfig,
                                  moreInfoResults: MoreInfoService,
                                  utils: Utils) extends FrontendController(mcc) with I18nSupport {
 
-
-
-
-  def onPageLoad: Action[AnyContent] = (getData andThen requireData).async { implicit request =>
-    request.userAnswers.location match {
-      case Some(location) => renderResultsPage(hideTC = false, location)
-      case None => Future.successful(Redirect(routes.LocationController.onPageLoad(NormalMode)))
-    }
+  def onPageLoad: Action[AnyContent] = (getData andThen requireData).async {
+    implicit request =>
+      request.userAnswers.location match {
+        case Some(location) => renderResultsPage(hideTC = request.userAnswers.notEligibleForTaxCredits, location)
+        case None           => Future.successful(Redirect(routes.LocationController.onPageLoad(NormalMode)))
+      }
   }
 
   def onPageLoadHideTC: Action[AnyContent] = (getData andThen requireData).async { implicit request =>
@@ -75,4 +73,6 @@ class ResultController @Inject()(val appConfig: FrontendAppConfig,
       )
     })
   }
+
+
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
@@ -131,12 +131,24 @@ object SelfEmployedOrApprenticeOrNeitherEnum extends Enumeration {
   implicit def enumFormats: Format[SelfEmployedOrApprenticeOrNeitherEnum] = EnumUtils.enumFormat(SelfEmployedOrApprenticeOrNeitherEnum)
 }
 
+
+/**
+  * It may seem odd that the SEVEREDISABILITYPREMIUM has the same value as HIGHRATEDISABILITYBENEFITS but this is
+  * because the text on the screen was changed from "High rate disability benefits" to "Severe disability premium"
+  * but the underlining value was left as "highRateDisabilityBenefits" [DL-1623: New divert journey].
+  *
+  * The reason for this temporary comment is a future JIRA [ DL-???? ] will provide both options
+  * "High rate disability benefits" and "Severe disability premium" and will require a new value to be defined
+  *
+  * This comment should be removed when DL-???? has been applied
+  */
 object WhichBenefitsEnum extends Enumeration {
   type WhichBenefitsEnum = Value
 
   val INCOMEBENEFITS = Value("incomeBenefits")
   val DISABILITYBENEFITS = Value("disabilityBenefits")
   val HIGHRATEDISABILITYBENEFITS = Value("highRateDisabilityBenefits")
+  val SEVEREDISABILITYPREMIUM = HIGHRATEDISABILITYBENEFITS
   val CARERSALLOWANCE = Value("carersAllowance")
 
   val enumReads: Reads[WhichBenefitsEnum] = EnumUtils.enumReads(WhichBenefitsEnum)
@@ -224,4 +236,17 @@ object StatutoryPayTypeEnum extends Enumeration {
   val enumWrites: Writes[StatutoryPayTypeEnum] = EnumUtils.enumWrites
 
   implicit def enumFormats: Format[StatutoryPayTypeEnum] = EnumUtils.enumFormat(StatutoryPayTypeEnum)
+}
+
+object TaxOrUniversalCreditsEnum extends Enumeration {
+  type TaxOrUniversalCreditsEnum = Value
+
+  val TC = Value("tc")
+  val UC = Value("uc")
+  val NONE = Value("none")
+
+  val enumReads: Reads[TaxOrUniversalCreditsEnum]   = EnumUtils.enumReads(TaxOrUniversalCreditsEnum)
+  val enumWrites: Writes[TaxOrUniversalCreditsEnum] = EnumUtils.enumWrites
+
+  implicit def enumFormats: Format[TaxOrUniversalCreditsEnum] = EnumUtils.enumFormat(TaxOrUniversalCreditsEnum)
 }

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigator.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigator.scala
@@ -267,3 +267,4 @@ class ChildcareNavigator @Inject() (utils: Utils) extends SubNavigator with Date
     }
   }
 }
+

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ResultControllerSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/controllers/ResultControllerSpec.scala
@@ -20,26 +20,43 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Lang
-import play.api.libs.json.JsString
+import play.api.libs.json.{JsBoolean, JsString}
 import play.api.test.Helpers._
 import services.MoreInfoService
 import uk.gov.hmrc.childcarecalculatorfrontend.connectors.FakeDataCacheConnector
 import uk.gov.hmrc.childcarecalculatorfrontend.controllers.actions.{DataRequiredAction, DataRetrievalAction, FakeDataRetrievalAction}
-import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.LocationId
-import uk.gov.hmrc.childcarecalculatorfrontend.models.{Location, NormalMode}
+import uk.gov.hmrc.childcarecalculatorfrontend.identifiers.{LocationId, YourChildcareVouchersId}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.views.ResultsViewModel
+import uk.gov.hmrc.childcarecalculatorfrontend.models.{Location, NormalMode}
 import uk.gov.hmrc.childcarecalculatorfrontend.services.ResultsService
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.Utils
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class ResultControllerSpec extends ControllerSpecBase with MockitoSugar{
 
-  val mockMoreInfoService: MoreInfoService = mock[MoreInfoService]
+  val mockMoreInfoService: MoreInfoService  = mock[MoreInfoService]
+  val resultService: ResultsService         = mock[ResultsService]
 
   implicit val l: Lang = mock[Lang]
+
+  val location = Location.ENGLAND
+
+  val cacheMapWithLocation = new CacheMap("id", Map(LocationId.toString -> JsString(location.toString)))
+
+  val cacheMapWithNoLocation = new CacheMap("id", Map("test" -> JsString(location.toString)))
+
+  val cacheMapNotEligibleForTaxCredits = new CacheMap( "id", Map(
+    LocationId.toString -> JsString(location.toString),
+    YourChildcareVouchersId.toString -> JsBoolean(true)
+  ))
+
+  val cacheMapEligibleForTaxCredits = new CacheMap( "id", Map(
+    LocationId.toString -> JsString(location.toString),
+    YourChildcareVouchersId.toString -> JsBoolean(false)
+  ))
 
   def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap,
                  resultService: ResultsService): ResultController =
@@ -63,10 +80,7 @@ class ResultControllerSpec extends ControllerSpecBase with MockitoSugar{
       val getRelevantData = new FakeDataRetrievalAction(Some(cacheMapWithLocation))
       val resultPage = controller(getRelevantData, resultService).onPageLoad(fakeRequest)
       status(resultPage) mustBe OK
-      contentAsString(resultPage) must include("15")
-      contentAsString(resultPage) must include("500")
-      contentAsString(resultPage) must include("600")
-      contentAsString(resultPage) must include("1,000")
+      contentAsString(resultPage) must include("Help you could get with your childcare costs")
     }
 
 
@@ -86,9 +100,30 @@ class ResultControllerSpec extends ControllerSpecBase with MockitoSugar{
         redirectLocation(result) mustBe Some(routes.SessionExpiredController.onPageLoad().url)
       }
     }
+
+    "suppress tax credit information" when {
+      "when user is NOT eligible for tax credits" in {
+        when(mockMoreInfoService.getSchemeContent(any(), any(), any())(any())) thenReturn List.empty
+        when(mockMoreInfoService.getSummary(any(), any())(any())) thenReturn None
+
+        val getRelevantData = new FakeDataRetrievalAction(Some(cacheMapNotEligibleForTaxCredits))
+        val resultPage = controller(getRelevantData, resultService).onPageLoad(fakeRequest)
+        status(resultPage) mustBe OK
+        contentAsString(resultPage) mustNot include("tax credit")
+      }
+    }
+
+    "NOT suppress tax credit information" when {
+      "when user IS eligible for tax credits" in {
+        when(mockMoreInfoService.getSchemeContent(any(), any(), any())(any())) thenReturn List.empty
+        when(mockMoreInfoService.getSummary(any(), any())(any())) thenReturn None
+
+        val getRelevantData = new FakeDataRetrievalAction(Some(cacheMapEligibleForTaxCredits))
+        val resultPage = controller(getRelevantData, resultService).onPageLoad(fakeRequest)
+        status(resultPage) mustBe OK
+        contentAsString(resultPage) must include("tax credit")
+      }
+    }
   }
-  val location = Location.ENGLAND
-  val cacheMapWithLocation = new CacheMap("id", Map(LocationId.toString -> JsString(location.toString)))
-  val cacheMapWithNoLocation = new CacheMap("id", Map("test" -> JsString(location.toString)))
-  val resultService: ResultsService = mock[ResultsService]
+
 }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/navigation/ChildcareNavigatorSpec.scala
@@ -917,7 +917,7 @@ class ChildcareNavigatorSpec extends SpecBase with OptionValues with MockitoSuga
     }
   }
 
-  "isEligibleForTaxCredits" must {
+  "notEligibleForTaxCredits" must {
     "redirect to the results page" when {
       "taxOrUniversal is not 'tc', neither parent or partner is on severe disability premium" in {
         val answers = mock[UserAnswers]
@@ -1005,3 +1005,4 @@ class ChildcareNavigatorSpec extends SpecBase with OptionValues with MockitoSuga
     }
   }
 }
+

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswersSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UserAnswersSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.{MustMatchers, OptionValues, WordSpec}
 import play.api.libs.json._
 import uk.gov.hmrc.childcarecalculatorfrontend.DataGenerator._
 import uk.gov.hmrc.childcarecalculatorfrontend.identifiers._
-import uk.gov.hmrc.childcarecalculatorfrontend.models.AboutYourChild
+import uk.gov.hmrc.childcarecalculatorfrontend.models._
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class UserAnswersSpec extends WordSpec with MustMatchers with OptionValues {
@@ -95,7 +95,6 @@ class UserAnswersSpec extends WordSpec with MustMatchers with OptionValues {
       val result = helper(answers).childrenOver16
       result.get.size mustBe 0
     }
-
 
     "return any children who are over 16" in {
 
@@ -251,7 +250,6 @@ class UserAnswersSpec extends WordSpec with MustMatchers with OptionValues {
       result mustEqual true
     }
   }
-
 
   ".multipleChildrenBelow16Yrs" must {
     "return true when the children aged exactly 16 and birthday before 31st of August are disabled" in {
@@ -713,4 +711,191 @@ class UserAnswersSpec extends WordSpec with MustMatchers with OptionValues {
       answers.max30HoursEnglandContent mustEqual None
     }
   }
+
+  ".isOnHighRateDisabilityBenefits" must {
+    "return true" when {
+      "'you' are on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.HIGHRATEDISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+
+      "'partner' is on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.HIGHRATEDISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+
+      "'both' are on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString      -> JsArray(Seq(JsString(WhichBenefitsEnum.HIGHRATEDISABILITYBENEFITS.toString))),
+          WhichBenefitsPartnerGetId.toString  -> JsArray(Seq(JsString(WhichBenefitsEnum.HIGHRATEDISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+    }
+
+    "return false" when {
+      "'you' are NOT on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.CARERSALLOWANCE.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+
+      "'partner' is NOT on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.DISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+
+      "'both' are NOT on high disability benefits" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString      -> JsArray(Seq(JsString(WhichBenefitsEnum.CARERSALLOWANCE.toString))),
+          WhichBenefitsPartnerGetId.toString  -> JsArray(Seq(JsString(WhichBenefitsEnum.DISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+    }
+  }
+
+
+
+  ".isOnSevereDisabilityPremium" must {
+    "return true" when {
+      "'you' are on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.SEVEREDISABILITYPREMIUM.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+
+      "'partner' is on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.SEVEREDISABILITYPREMIUM.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+
+      "'both' are on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.SEVEREDISABILITYPREMIUM.toString))),
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.SEVEREDISABILITYPREMIUM.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual true
+      }
+    }
+
+    "return false" when {
+      "'you' are NOT on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.CARERSALLOWANCE.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+
+      "'partner' is NOT on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.DISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+
+      "'both' are NOT on severe disability premium" in {
+        val answers = helper(cacheMap(
+          WhichBenefitsYouGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.CARERSALLOWANCE.toString))),
+          WhichBenefitsPartnerGetId.toString -> JsArray(Seq(JsString(WhichBenefitsEnum.DISABILITYBENEFITS.toString)))
+        ))
+
+        answers.isOnHighRateDisabilityBenefits mustEqual false
+      }
+    }
+
+  }
+
+  ".isAlreadyReceivingTaxCredits" must {
+    "return true" when {
+      "Someone has tax credits" in {
+        val answers = helper(cacheMap(TaxOrUniversalCreditsId.toString -> JsString(TaxOrUniversalCreditsEnum.TC.toString)))
+        answers.isAlreadyReceivingTaxCredits mustEqual true
+      }
+    }
+    "return false" when {
+      "Someone has universal credits" in {
+        val answers = helper(cacheMap(TaxOrUniversalCreditsId.toString -> JsString(TaxOrUniversalCreditsEnum.UC.toString)))
+        answers.isAlreadyReceivingTaxCredits mustEqual false
+      }
+      "Someone has neither universal credits or tax credits" in {
+        val answers = helper(cacheMap())
+        answers.isAlreadyReceivingTaxCredits mustEqual false
+      }
+    }
+  }
+
+
+  ".isGettingChildVouchers" must {
+    "return true" when {
+      "'you' get child care vouchers" in {
+        val answers = helper(cacheMap(YourChildcareVouchersId.toString -> JsBoolean(true)))
+        answers.isGettingChildVouchers mustEqual true
+      }
+      "'partner' gets child care vouchers" in {
+        val answers = helper(cacheMap(PartnerChildcareVouchersId.toString -> JsBoolean(true)))
+        answers.isGettingChildVouchers mustEqual true
+      }
+      "asked 'who gets child care vouchers'" when {
+        "answering 'you" in {
+          val answers = helper(cacheMap(WhoGetsVouchersId.toString -> JsString(YouPartnerBothEnum.YOU.toString)))
+          answers.isGettingChildVouchers mustEqual true
+        }
+        "answering 'partner" in {
+          val answers = helper(cacheMap(WhoGetsVouchersId.toString -> JsString(YouPartnerBothEnum.PARTNER.toString)))
+          answers.isGettingChildVouchers mustEqual true
+        }
+        "answering 'both" in {
+          val answers = helper(cacheMap(WhoGetsVouchersId.toString -> JsString(YouPartnerBothEnum.BOTH.toString)))
+          answers.isGettingChildVouchers mustEqual true
+        }
+      }
+    }
+
+    "return false" when {
+      "'you' dont get child care vouchers" in {
+        val answers = helper(cacheMap(YourChildcareVouchersId.toString -> JsBoolean(false)))
+        answers.isGettingChildVouchers mustEqual false
+      }
+      "'you' never answered the question about getting child care vouchers" in {
+        val answers = helper(cacheMap())
+        answers.isGettingChildVouchers mustEqual false
+      }
+
+      "'partner' does not get child care vouchers" in {
+        val answers = helper(cacheMap(PartnerChildcareVouchersId.toString -> JsBoolean(false)))
+        answers.isGettingChildVouchers mustEqual false
+      }
+      "'partner' never answered the question about getting child care vouchers" in {
+        val answers = helper(cacheMap())
+        answers.isGettingChildVouchers mustEqual false
+      }
+      "neither you/partner/both" in {
+        val answers = helper(cacheMap(WhoGetsVouchersId.toString -> JsString(YouPartnerBothNeitherEnum.NEITHER.toString)))
+        answers.isGettingChildVouchers mustEqual false
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
# DL-2044 Suppression of tax credit information

**Bug fix**
This bug fix is to suppress 'tax credit' information from the results page when the user has answered
a particular combination of questions. Details of these questions are contained within https://jira.tools.tax.service.gov.uk/browse/DL-2044

## Other related PR's
https://github.com/hmrc/childcare-calculator-acceptance-tests/pull/33

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
