### PR TITLE
DL-2184 Fix issue of content not appearing

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
@@ -91,13 +91,11 @@
                 </div>
             }
 
-
-
             @if(model.noOfEligibleSchemes(hideTC) > 1) {
 
                 <h2 class="heading-medium">@messages("result.more.info.title")</h2>
 
-                @if(model.noOfEligibleSchemes(hideTC) == 4  && !hideTC) {
+                @if(model.noOfEligibleSchemes(hideTC) == 4) {
                     <p>@messages("result.more.info.para")</p>
                     <ul class="bullets">
                         <li>@messages("result.schemes.free.hours.eligibility.guidance.with.tc.bullet")</li>
@@ -105,14 +103,14 @@
                         <li>@messages("result.schemes.tfc.tc.vouchers.eligibility.guidance.bullet")</li>
                     </ul>
                 } else {
-                    @if(model.isEligibleForAllButVouchers && !hideTC) {
+                    @if(model.isEligibleForAllButVouchers) {
                         <p>@messages("result.more.info.para")</p>
                         <ul class="bullets">
                             <li>@messages("result.schemes.free.hours.eligibility.guidance.with.tc.bullet")</li>
                             <li>@messages("result.schemes.tfc.ineligibility.taxCredits.guidance.bullet")</li>
                         </ul>
                     }
-                    @if(model.isEligibleForAllButTc && !hideTC) {
+                    @if(model.isEligibleForAllButTc) {
                         <p>@messages("result.more.info.para")</p>
                         <ul class="bullets">
                             <li>@messages("result.schemes.free.hours.eligibility.guidance.bullet")</li>
@@ -120,7 +118,7 @@
                         </ul>
                     }
 
-                    @if(model.isEligibleForAllButTfc && !hideTC) {
+                    @if(model.isEligibleForAllButTfc) {
                         <p>@messages("result.more.info.para")</p>
                         <ul class="bullets">
                             <li>@messages("result.schemes.free.hours.eligibility.guidance.with.tc.bullet")</li>
@@ -128,15 +126,15 @@
                         </ul>
                     }
 
-                    @if(model.isEligibleForAllButFreeHours && !hideTC) {
+                    @if(model.isEligibleForAllButFreeHours) {
                         <p>@messages("result.schemes.tfc.tc.vouchers.eligibility.guidance.para")</p>
                     }
 
-                    @if(model.isEligibleOnlyForFreeHoursAndTc && !hideTC) {
+                    @if(model.isEligibleOnlyForFreeHoursAndTc) {
                         <p>@messages("result.schemes.free.hours.eligibility.guidance.with.tc.para")</p>
                     }
 
-                    @if(model.isEligibleOnlyForTCAndEsc && !hideTC) {
+                    @if(model.isEligibleOnlyForTCAndEsc) {
                         <p>@messages("result.schemes.tax.credit.eligibility.with.vouchers.guidance.para")</p>
                     }
 
@@ -148,7 +146,7 @@
                         <p>@messages("result.schemes.tfc.ineligibility.vouchers.guidance.para")</p>
                     }
 
-                    @if(model.isEligibleOnlyForTCAndTfc && !hideTC) {
+                    @if(model.isEligibleOnlyForTCAndTfc) {
                         <p>@messages("result.schemes.tfc.ineligibility.taxCredits.guidance.para")</p>
                     }
                 }

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -11,7 +11,7 @@ object FrontendBuild extends Build with MicroService {
 
 private object AppDependencies {
   private val bootstrapPlayVersion = "0.42.0"
-  private val govukTemplateVersion = "5.36.0-play-26"
+  private val govukTemplateVersion = "5.37.0-play-26"
   private val playUiVersion = "7.40.0-play-26"
   private val hmrcTestVersion = "3.9.0-play-26"
   private val scalaTestVersion = "3.0.8"
@@ -23,7 +23,7 @@ private object AppDependencies {
   private val playReactivemongoVersion = "7.20.0-play-26"
   private val playConditionalFormMappingVersion = "1.1.0-play-26"
   private val playLanguageVersion = "3.4.0"
-  private val taxYearVersion = "0.4.0"
+  private val taxYearVersion = "0.6.0"
   private val playJavaVersion = "2.6.12"
 
   private val hmrc = "uk.gov.hmrc"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.6.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 


### PR DESCRIPTION
# JDL-2184 Missing content in result page

**Bug fix

The results page has a section that presents dynamic content based on how many entitlements are in place for the current result and cross scheme eligibility. This content is not working in at least one scenario.

The variable hideTC is set depending on whether the user is eligible for tax credits.
It is then used to set the available TC scheme TC
The presence of this TC is used to determine the eligibility for Tax credits and the value of hideTC is therefore implicitly already known.

There is form logic like the below for the results page:
 @if(model.isEligibleForAllButTc && !hideTC) {
...

This actually says "if the users is not eligible for TC AND is also eligible for TC" and cannot ever be true.

In matter of fact the && !hideTC condition is not required at all and can be removed from the form. The helper functions like isEligibleForAllButTc are checking if the TC scheme is empty already which was already set based on the value if hideTC. 
It has therefore been removed.

## Checklist

 - [x ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ x]  I've run a dependency check to ensure all dependencies are up to date
