### PR TITLE
Fixed duplication of 2 year old section in results page

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/result.scala.html
@@ -73,7 +73,7 @@
 
             @resultEligible(model, utils, hideTC)
 
-            @if(model.noOfEligibleSchemes(hideTC) < 4) {
+            @if(!model.isEligibleToAllSchemes(hideTC)) {
                 <h2 class="resultNotEligibleHeading visuallyhidden">@messages("result.not.eligible.title")</h2>
                 @resultNotEligible(model, hideTC)
             }


### PR DESCRIPTION
# DL-2247 Doubling up message in #results page for free hours message

The existing code for the diverted journey is incomplete.
the last PR fixed one aspect. This PR fixes the duplication of 2 year old free hours.
The duplication does more than this.
Essentially the code used to have mutually exclusive blocks. One where the user didn't have all the eligible schemes and one where the user had all the eligible schemes. 
that logic isn't immediately obvious and it still had the hard coded value of 4 schemes when it is now conditional. The fix makes those blocks mutually exclusive again and adds in the correct conditional check. the nested code then handles correctly too.

## Checklist

 - [x ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x ]  I've run a dependency check to ensure all dependencies are up to date