### PR TITLE
DL-4709 - Age band change & NMW update

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourAgeForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourAgeForm.scala
@@ -42,8 +42,8 @@ object YourAgeForm extends FormErrorHelper {
   def options = Seq(
     InputOption("yourAge", AgeEnum.UNDER18.toString),
     InputOption("yourAge", AgeEnum.EIGHTEENTOTWENTY.toString),
-    InputOption("yourAge", AgeEnum.TWENTYONETOTWENTYFOUR.toString),
-    InputOption("yourAge", AgeEnum.OVERTWENTYFOUR.toString)
+    InputOption("yourAge", AgeEnum.TWENTYONETOTWENTYTWO.toString),
+    InputOption("yourAge", AgeEnum.OVERTWENTYTWO.toString)
   )
 
 

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourPartnersAgeForm.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/forms/YourPartnersAgeForm.scala
@@ -41,8 +41,8 @@ object YourPartnersAgeForm extends FormErrorHelper {
   def options = Seq(
     InputOption("yourPartnersAge", AgeEnum.UNDER18.toString),
     InputOption("yourPartnersAge", AgeEnum.EIGHTEENTOTWENTY.toString),
-    InputOption("yourPartnersAge", AgeEnum.TWENTYONETOTWENTYFOUR.toString),
-    InputOption("yourPartnersAge", AgeEnum.OVERTWENTYFOUR.toString)
+    InputOption("yourPartnersAge", AgeEnum.TWENTYONETOTWENTYTWO.toString),
+    InputOption("yourPartnersAge", AgeEnum.OVERTWENTYTWO.toString)
   )
 
   def optionIsValid(value: String): Boolean = options.exists(o => o.value == value)

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/models/Enums.scala
@@ -109,8 +109,8 @@ object AgeEnum extends Enumeration {
 
   val UNDER18 = Value("UNDER18")
   val EIGHTEENTOTWENTY = Value("EIGHTEENTOTWENTY")
-  val TWENTYONETOTWENTYFOUR = Value("TWENTYONETOTWENTYFOUR")
-  val OVERTWENTYFOUR = Value("OVERTWENTYFOUR")
+  val TWENTYONETOTWENTYTWO= Value("TWENTYONETOTWENTYTWO")
+  val OVERTWENTYTWO = Value("OVERTWENTYTWO")
 
   val enumReads: Reads[AgeEnum] = EnumUtils.enumReads(AgeEnum)
   val enumWrites: Writes[AgeEnum] = EnumUtils.enumWrites

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/models/mappings/UserAnswerToHousehold.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/models/mappings/UserAnswerToHousehold.scala
@@ -156,8 +156,8 @@ class UserAnswerToHousehold @Inject()(appConfig: FrontendAppConfig, utils: Utils
       x.toUpperCase match {
         case "UNDER18" => Some(AgeEnum.UNDER18)
         case "EIGHTEENTOTWENTY" => Some(AgeEnum.EIGHTEENTOTWENTY)
-        case "TWENTYONETOTWENTYFOUR" => Some(AgeEnum.TWENTYONETOTWENTYFOUR)
-        case "OVERTWENTYFOUR" => Some(AgeEnum.OVERTWENTYFOUR)
+        case "TWENTYONETOTWENTYTWO" => Some(AgeEnum.TWENTYONETOTWENTYTWO)
+        case "OVERTWENTYTWO" => Some(AgeEnum.OVERTWENTYTWO)
       }
     case _ => None
   }

--- a/conf/messages
+++ b/conf/messages
@@ -370,8 +370,8 @@ yourPartnersAge.title = What’s your partner’s age?
 yourPartnersAge.heading = What’s your partner’s age?
 yourPartnersAge.UNDER18 = Under 18
 yourPartnersAge.EIGHTEENTOTWENTY = 18 to 20
-yourPartnersAge.TWENTYONETOTWENTYFOUR = 21 to 24
-yourPartnersAge.OVERTWENTYFOUR = 25 or over
+yourPartnersAge.TWENTYONETOTWENTYTWO= 21 to 22
+yourPartnersAge.OVERTWENTYTWO = 23 or over
 yourPartnersAge.error.notCompleted = Select your partner’s age
 yourPartnersAge.checkYourAnswersLabel = What’s your partner’s age?
 
@@ -379,8 +379,8 @@ yourAge.title = What’s your age?
 yourAge.heading = What’s your age?
 yourAge.UNDER18 = Under 18
 yourAge.EIGHTEENTOTWENTY = 18 to 20
-yourAge.TWENTYONETOTWENTYFOUR = 21 to 24
-yourAge.OVERTWENTYFOUR = 25 or over
+yourAge.TWENTYONETOTWENTYTWO= 21 to 22
+yourAge.OVERTWENTYTWO = 23 or over
 yourAge.error.notCompleted = Select your age
 yourAge.checkYourAnswersLabel = What’s your age?
 

--- a/conf/nmw.conf
+++ b/conf/nmw.conf
@@ -14,6 +14,7 @@
 
 nmw = [
   {
+    // BEFORE DEPLOYMENT - change rule date to 01-04-2021
     rule-date: 01-02-2021,
     apprentice: 68.80,
     UNDER18: 73.92,

--- a/conf/nmw.conf
+++ b/conf/nmw.conf
@@ -14,6 +14,14 @@
 
 nmw = [
   {
+    rule-date: 01-02-2021,
+    apprentice: 68.80,
+    UNDER18: 73.92,
+    EIGHTEENTOTWENTY: 104.96,
+    TWENTYONETOTWENTYTWO: 133.76,
+    OVERTWENTYTWO: 142.56
+  },
+  {
     rule-date: 01-04-2020,
     apprentice: 66.40,
     UNDER18: 72.80,

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/cascadeUpserts/MaximumHoursCascadeUpsertSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/cascadeUpserts/MaximumHoursCascadeUpsertSpec.scala
@@ -36,8 +36,8 @@ class MaximumHoursCascadeUpsertSpec extends SpecBase with CascadeUpsertBase {
 
   lazy val under18: String = AgeEnum.UNDER18.toString
   lazy val eighteenToTwenty: String = AgeEnum.EIGHTEENTOTWENTY.toString
-  lazy val twentyToTwentyFour: String = AgeEnum.TWENTYONETOTWENTYFOUR.toString
-  lazy val overTwentyFive: String = AgeEnum.OVERTWENTYFOUR.toString
+  lazy val twentyToTwentyFour: String = AgeEnum.TWENTYONETOTWENTYTWO.toString
+  lazy val overTwentyFive: String = AgeEnum.OVERTWENTYTWO.toString
 
 
   "saving the doYouLiveWithPartner" must {

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/cascadeUpserts/MaximumHoursCascadeUpsertSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/cascadeUpserts/MaximumHoursCascadeUpsertSpec.scala
@@ -36,8 +36,8 @@ class MaximumHoursCascadeUpsertSpec extends SpecBase with CascadeUpsertBase {
 
   lazy val under18: String = AgeEnum.UNDER18.toString
   lazy val eighteenToTwenty: String = AgeEnum.EIGHTEENTOTWENTY.toString
-  lazy val twentyToTwentyFour: String = AgeEnum.TWENTYONETOTWENTYTWO.toString
-  lazy val overTwentyFive: String = AgeEnum.OVERTWENTYTWO.toString
+  lazy val twentyToTwentyTwo: String = AgeEnum.TWENTYONETOTWENTYTWO.toString
+  lazy val twentyToTwentyThree: String = AgeEnum.OVERTWENTYTWO.toString
 
 
   "saving the doYouLiveWithPartner" must {
@@ -631,16 +631,16 @@ class MaximumHoursCascadeUpsertSpec extends SpecBase with CascadeUpsertBase {
       val originalCacheMap = new CacheMap("id", Map(YourAgeId.toString->JsString(under18),
         YourMinimumEarningsId.toString->JsBoolean(false),AreYouSelfEmployedOrApprenticeId.toString -> JsBoolean(true),YourSelfEmployedId.toString ->JsBoolean(true) ))
 
-      val result = cascadeUpsert(YourAgeId.toString, twentyToTwentyFour, originalCacheMap)
-      result.data mustBe Map(YourAgeId.toString->JsString(twentyToTwentyFour))
+      val result = cascadeUpsert(YourAgeId.toString, twentyToTwentyTwo, originalCacheMap)
+      result.data mustBe Map(YourAgeId.toString->JsString(twentyToTwentyTwo))
     }
 
     "removing an existing yourMinimumEarnings  when user change the selection to age over 25" in {
       val originalCacheMap = new CacheMap("id", Map(YourAgeId.toString->JsString(under18),
         YourMinimumEarningsId.toString->JsBoolean(true)))
 
-      val result = cascadeUpsert(YourAgeId.toString, overTwentyFive, originalCacheMap)
-      result.data mustBe Map(YourAgeId.toString->JsString(overTwentyFive))
+      val result = cascadeUpsert(YourAgeId.toString, twentyToTwentyThree, originalCacheMap)
+      result.data mustBe Map(YourAgeId.toString->JsString(twentyToTwentyThree))
     }
 
     " not removing an existing your minimumEarnings  when user change the selection to age 18-20 again" in {
@@ -675,16 +675,16 @@ class MaximumHoursCascadeUpsertSpec extends SpecBase with CascadeUpsertBase {
       val originalCacheMap = new CacheMap("id", Map(YourPartnersAgeId.toString->JsString(under18), PartnerMinimumEarningsId.toString->JsBoolean(false),
         PartnerSelfEmployedOrApprenticeId.toString -> JsBoolean(true),PartnerSelfEmployedId.toString-> JsBoolean(true) ))
 
-      val result = cascadeUpsert(YourPartnersAgeId.toString, twentyToTwentyFour, originalCacheMap)
-      result.data mustBe Map(YourPartnersAgeId.toString->JsString(twentyToTwentyFour))
+      val result = cascadeUpsert(YourPartnersAgeId.toString, twentyToTwentyTwo, originalCacheMap)
+      result.data mustBe Map(YourPartnersAgeId.toString->JsString(twentyToTwentyTwo))
     }
 
     "removing an existing yourMinimumEarnings, maximumEarnings when user change the selection to age over 25" in {
       val originalCacheMap = new CacheMap("id", Map(YourPartnersAgeId.toString->JsString(under18),
         PartnerMinimumEarningsId.toString->JsBoolean(true)))
 
-      val result = cascadeUpsert(YourPartnersAgeId.toString, overTwentyFive, originalCacheMap)
-      result.data mustBe Map(YourPartnersAgeId.toString->JsString(overTwentyFive))
+      val result = cascadeUpsert(YourPartnersAgeId.toString, twentyToTwentyThree, originalCacheMap)
+      result.data mustBe Map(YourPartnersAgeId.toString->JsString(twentyToTwentyThree))
     }
 
     "not removing an existing yourMinimumEarnings maximum earnings when user change the selection to age under18 again" in {

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/models/mappings/UserAnswerToHouseholdSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/models/mappings/UserAnswerToHouseholdSpec.scala
@@ -154,7 +154,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(120.0)),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(32000.0))))
@@ -166,7 +166,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
         when(answers.parentEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
@@ -179,7 +179,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.NEITHER))),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(32000.0))))
@@ -191,7 +191,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.NEITHER.toString)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
@@ -205,7 +205,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(amount = 120, employmentStatus = Some(EmploymentStatusEnum.APPRENTICE))),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(32000.0))))
@@ -217,7 +217,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.APPRENTICE.toString)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
@@ -231,7 +231,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(amount = 120, employmentStatus = Some(EmploymentStatusEnum.SELFEMPLOYED),
                                                  selfEmployedIn12Months = Some(true))),
           maximumEarnings = Some(false),
@@ -244,7 +244,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.SELFEMPLOYED.toString)
         when(answers.yourSelfEmployed) thenReturn Some(true)
@@ -259,7 +259,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.SELFEMPLOYED),
             selfEmployedIn12Months = Some(false))),
           maximumEarnings = Some(false),
@@ -272,7 +272,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.SELFEMPLOYED.toString)
         when(answers.yourSelfEmployed) thenReturn Some(false)
@@ -287,7 +287,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(120.0)),
           maximumEarnings = Some(false),
           lastYearlyIncome = Some(Income(
@@ -308,7 +308,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
         when(answers.parentEmploymentIncomePY) thenReturn Some(BigDecimal(32000.0))
@@ -321,7 +321,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(120.0)),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(
@@ -342,7 +342,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
         when(answers.parentEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
@@ -355,7 +355,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(120.0)),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(
@@ -382,7 +382,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
         when(answers.parentEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
@@ -396,7 +396,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(120.0)),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(
@@ -420,7 +420,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(false)
         when(answers.parentEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
@@ -434,7 +434,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.NEITHER))),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -465,7 +465,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.NEITHER.toString)
@@ -486,7 +486,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.APPRENTICE),
                                                  amount = BigDecimal(112))),
           maximumEarnings = Some(true),
@@ -519,7 +519,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.APPRENTICE.toString)
@@ -540,7 +540,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.SELFEMPLOYED),
             selfEmployedIn12Months = Some(true), amount = BigDecimal(112))),
           maximumEarnings = Some(true),
@@ -572,7 +572,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(SelfEmployedOrApprenticeOrNeitherEnum.SELFEMPLOYED.toString)
@@ -593,7 +593,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -624,7 +624,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -645,7 +645,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -676,7 +676,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -695,7 +695,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -728,7 +728,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -747,7 +747,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -780,7 +780,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -800,7 +800,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(
@@ -839,7 +839,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -858,7 +858,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -900,7 +900,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -950,7 +950,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(54.9)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.OVERTWENTYFOUR),
+          ageRange = Some(AgeEnum.OVERTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(employmentStatus = Some(EmploymentStatusEnum.SELFEMPLOYED), selfEmployedIn12Months = Some(true))),
           maximumEarnings = Some(false),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(32000.0))))
@@ -962,7 +962,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(EmploymentStatusEnum.SELFEMPLOYED.toString)
         when(answers.yourSelfEmployed) thenReturn Some(true)
@@ -981,7 +981,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(false)
         when(answers.yourChildcareVouchers) thenReturn Some(false)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(54.9))
-        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.OVERTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(false)
         when(answers.areYouSelfEmployedOrApprentice) thenReturn Some(EmploymentStatusEnum.SELFEMPLOYED.toString)
         when(answers.yourSelfEmployed) thenReturn Some(true)
@@ -1022,7 +1022,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(21000.0)))),
@@ -1043,7 +1043,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -1065,7 +1065,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("partner")
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.partnerWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.partnerChildcareVouchers) thenReturn Some(true)
         when(answers.partnerEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
         when(answers.partnerEmploymentIncomePY) thenReturn Some(BigDecimal(21000.0))
@@ -1085,7 +1085,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("partner")
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.partnerWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.partnerChildcareVouchers) thenReturn Some(false)
         when(answers.partnerEmploymentIncomeCY) thenReturn Some(BigDecimal(32000.0))
         when(answers.partnerEmploymentIncomePY) thenReturn Some(BigDecimal(21000.0))
@@ -1102,7 +1102,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(72000.0))))
@@ -1122,7 +1122,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.whoIsInPaidEmployment) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
@@ -1141,7 +1141,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           lastYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(23000.0))))
@@ -1160,7 +1160,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.location) thenReturn Some(Location.WALES)
         when(answers.doYouLiveWithPartner) thenReturn Some(true)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomePY) thenReturn Some(EmploymentIncomePY(23000.0, 20000.0))
@@ -1177,7 +1177,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(employmentIncome = Some(BigDecimal(72000.0))))
@@ -1198,7 +1198,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 0))
@@ -1217,7 +1217,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1254,7 +1254,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.YOU.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1275,7 +1275,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1310,7 +1310,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.PARTNER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1330,7 +1330,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1365,7 +1365,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.PARTNER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1385,7 +1385,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1420,7 +1420,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1441,7 +1441,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NOTSURE),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1480,7 +1480,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YesNoUnsureEnum.NOTSURE.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1500,7 +1500,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1537,7 +1537,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.PARTNER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1557,7 +1557,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1594,7 +1594,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.PARTNER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1614,7 +1614,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1649,7 +1649,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.PARTNER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1669,7 +1669,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1706,7 +1706,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.YOU.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1726,7 +1726,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.YES),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1759,7 +1759,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothEnum.BOTH.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))
@@ -1779,7 +1779,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         val parent = Claimant(
           hours = Some(BigDecimal(32.1)),
           escVouchers = Some(YesNoUnsureEnum.NO),
-          ageRange = Some(AgeEnum.TWENTYONETOTWENTYFOUR),
+          ageRange = Some(AgeEnum.TWENTYONETOTWENTYTWO),
           minimumEarnings = Some(MinimumEarnings(112.0)),
           maximumEarnings = Some(true),
           currentYearlyIncome = Some(Income(
@@ -1812,7 +1812,7 @@ class UserAnswerToHouseholdSpec extends SchemeSpec with MockitoSugar with Before
         when(answers.whoIsInPaidEmployment) thenReturn Some("both")
         when(answers.whoGetsVouchers) thenReturn Some(YouPartnerBothNeitherNotSureEnum.NEITHER.toString)
         when(answers.parentWorkHours) thenReturn Some(BigDecimal(32.1))
-        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYFOUR.toString)
+        when(answers.yourAge) thenReturn Some(AgeEnum.TWENTYONETOTWENTYTWO.toString)
         when(answers.yourMinimumEarnings) thenReturn Some(true)
         when(answers.yourMaximumEarnings) thenReturn Some(true)
         when(answers.employmentIncomeCY) thenReturn Some(EmploymentIncomeCY(72000.0, 32000.0))

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UtilsSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UtilsSpec.scala
@@ -195,27 +195,27 @@ class UtilsSpec extends SpecBase {
       }
 
       "return the 2019 earnings value for 21-24 year old on day of tax year change" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("TWENTYONETOTWENTYFOUR")) mustBe 123
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("TWENTYONETOTWENTYTWO")) mustBe 123
       }
 
       "return the 2019 earnings value for 21-24 year old on 1st April 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("TWENTYONETOTWENTYFOUR")) mustBe 123
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("TWENTYONETOTWENTYTWO")) mustBe 123
       }
 
       "return the 2018 earnings value for 21-24 year old on 31 March 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("TWENTYONETOTWENTYFOUR")) mustBe 118
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("TWENTYONETOTWENTYTWO")) mustBe 118
       }
 
       "return the 2019 earnings value for over 24 year old on day of tax year change" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("OVERTWENTYFOUR")) mustBe 131
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("OVERTWENTYTWO")) mustBe 131
       }
 
       "return the 2019 earnings value for over 24 year old on 1st April 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("OVERTWENTYFOUR")) mustBe 131
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("OVERTWENTYTWO")) mustBe 131
       }
 
       "return the 2018 earnings value for over 24 old on 31 March 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("OVERTWENTYFOUR")) mustBe 125
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("OVERTWENTYTWO")) mustBe 125
       }
     }
   }

--- a/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UtilsSpec.scala
+++ b/test/uk/gov/hmrc/childcarecalculatorfrontend/utils/UtilsSpec.scala
@@ -195,27 +195,27 @@ class UtilsSpec extends SpecBase {
       }
 
       "return the 2019 earnings value for 21-24 year old on day of tax year change" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("TWENTYONETOTWENTYTWO")) mustBe 123
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("TWENTYONETOTWENTYFOUR")) mustBe 123
       }
 
       "return the 2019 earnings value for 21-24 year old on 1st April 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("TWENTYONETOTWENTYTWO")) mustBe 123
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("TWENTYONETOTWENTYFOUR")) mustBe 123
       }
 
       "return the 2018 earnings value for 21-24 year old on 31 March 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("TWENTYONETOTWENTYTWO")) mustBe 118
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("TWENTYONETOTWENTYFOUR")) mustBe 118
       }
 
       "return the 2019 earnings value for over 24 year old on day of tax year change" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("OVERTWENTYTWO")) mustBe 131
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-06"), Some("OVERTWENTYFOUR")) mustBe 131
       }
 
       "return the 2019 earnings value for over 24 year old on 1st April 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("OVERTWENTYTWO")) mustBe 131
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-04-01"), Some("OVERTWENTYFOUR")) mustBe 131
       }
 
       "return the 2018 earnings value for over 24 old on 31 March 2019" in {
-        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("OVERTWENTYTWO")) mustBe 125
+        utils.getEarningsForAgeRange(frontendAppConfig.configuration, LocalDate.parse("2019-03-31"), Some("OVERTWENTYFOUR")) mustBe 125
       }
     }
   }


### PR DESCRIPTION
# DL-4709 - Age band change & NMW update

The National Living Wage (NLW) National Minimum Wage (NMW) rates are changing again from April 2021 but this time, two of the age bands are changing as well. These rates change on 1st April every year. Also, for 2021/2022:

The “21 to 24 years old” band would become the “21 to 22 years old” band.
The “25 years and over” band would become the “23 years and over” band.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
