### PR TITLE
DL-7272 - Hide childcare section for childless users

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/services/ResultsService.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/services/ResultsService.scala
@@ -66,6 +66,7 @@ class ResultsService @Inject()(eligibilityService: EligibilityService,
 
     val resultViewModel = ResultsViewModel(firstParagraph = firstParagraphBuilder.buildFirstParagraph(answers),
       location = location, childAgedTwo = answers.childAgedTwo.getOrElse(false),
+      childAgedThreeOrFour = answers.childAgedThreeOrFour.getOrElse(false),
       tcSchemeInEligibilityMsg = tcSchemeInEligibilityMsgBuilder.getMessage(answers),hasChildcareCosts = childcareCost,
       hasCostsWithApprovedProvider = approvedProvider,
       isAnyoneInPaidEmployment = paidEmployment,

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/resultNotEligible.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/resultNotEligible.scala.html
@@ -156,7 +156,7 @@ schemeResult: playComponents.scheme_result,
         </p>
     }
 
-    @if(model.location != Location.ENGLAND
+    @if(model.location != Location.ENGLAND && (model.childAgedTwo || model.childAgedThreeOrFour)
         && !(model.location == Location.WALES
             && (model.yourEarnings.exists(earnings => Set(EarningsEnum.LessThanMinimum, EarningsEnum.GreaterThanMaximum).contains(earnings))))) {
 


### PR DESCRIPTION
# DL-7272 - Hide childcare section for childless users

This hides the new "You could get extra help" section at the bottom of the results page if the user doesn't have a child aged two or a child aged three or four.

These users don't need childcare guidance as they don't have children.

Example journey: scotland -> have no kids -> don't have childcare costs

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
