### PR TITLE
DL-12793 Adding a guard on tfc/free hours ineligible message checks

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/models/views/ResultsViewModel.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/models/views/ResultsViewModel.scala
@@ -43,7 +43,8 @@ case class ResultsViewModel(firstParagraph: List[String] = List.empty,
 
   def isEligibleOnlyToMinimumFreeHours: Boolean = esc.isEmpty && tfc.isEmpty && tc.isEmpty && (freeHours.contains(BigDecimal(freeHoursForEngland)) || freeHours.contains(BigDecimal(freeHoursForWales)) || freeHours.contains(BigDecimal(freeHoursForScotland)) || freeHours.contains(BigDecimal(freeHoursForNI)))
   def isEligibleToMaximumFreeHours: Boolean = freeHours.contains(BigDecimal(30))
-  def hasIneligibleMessages: Boolean = freeChildcareWorkingParentsEligibilityMsg.nonEmpty || taxFreeChildcareEligibilityMsg.nonEmpty
+  def hasIneligibleMessages: Boolean = (freeChildcareWorkingParentsEligibilityMsg.nonEmpty && !freeChildcareWorkingParents) ||
+    (taxFreeChildcareEligibilityMsg.nonEmpty && tfc.isEmpty)
   def isEligibleToAllSchemes: Boolean = noOfEligibleSchemes == 4
   def showTwoYearOldInfo: Boolean = {
     if (childrenAgeGroups.contains(TwoYears)) {

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/services/ResultsService.scala
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/services/ResultsService.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.childcarecalculatorfrontend.FrontendAppConfig
 import uk.gov.hmrc.childcarecalculatorfrontend.models.EarningsEnum._
 import uk.gov.hmrc.childcarecalculatorfrontend.models.Location._
 import uk.gov.hmrc.childcarecalculatorfrontend.models.SchemeEnum._
-import uk.gov.hmrc.childcarecalculatorfrontend.models.schemes.{FreeChildcareWorkingParents, FreeHours, MaxFreeHours}
+import uk.gov.hmrc.childcarecalculatorfrontend.models.schemes.{FreeChildcareWorkingParents, FreeHours, MaxFreeHours, TaxFreeChildcare}
 import uk.gov.hmrc.childcarecalculatorfrontend.models.views.ResultsViewModel
 import uk.gov.hmrc.childcarecalculatorfrontend.models.{Location, _}
 import uk.gov.hmrc.childcarecalculatorfrontend.utils.ChildcareConstants._
@@ -38,6 +38,7 @@ class ResultsService @Inject()(appConfig: FrontendAppConfig,
                                freeHours: FreeHours,
                                freeChildcareWorkingParents: FreeChildcareWorkingParents,
                                maxFreeHours: MaxFreeHours,
+                               taxFreeChildcare: TaxFreeChildcare,
                                firstParagraphBuilder: FirstParagraphBuilder,
                                utils: Utils)(implicit ec: ExecutionContext) {
   def getResultsViewModel(answers: UserAnswers, location: Location)
@@ -182,7 +183,8 @@ class ResultsService @Inject()(appConfig: FrontendAppConfig,
 
     lazy val msgKey = "result.tfc.ineligible"
 
-    answers match {
+    taxFreeChildcare.eligibility(answers) match {
+      case Eligible => None
       case _ if answers.childcareCosts.contains(no) || answers.approvedProvider.contains(NO) =>
         Some(messages(s"$msgKey.noCostsWithApprovedProvider"))
       case _ if hasPartner && !bothInPaidWork =>
@@ -218,8 +220,8 @@ class ResultsService @Inject()(appConfig: FrontendAppConfig,
     lazy val bothEligibleMaxEarnings = !answers.eitherOfYouMaximumEarnings.getOrElse(false)
 
     lazy val msgKey = "result.free.childcare.working.parents.ineligible"
-    answers match {
-      case _ if !inEngland => None
+    freeChildcareWorkingParents.eligibility(answers) match {
+      case Eligible => None
       case _ if !hasEligibileChildren =>
         Some(messages(s"$msgKey.noChildrenInAgeRange"))
       case _ if hasPartner && !bothInPaidWork =>


### PR DESCRIPTION
This has been raised by the DSM. Issue is that the checks that generate the different error messages for tfc and working parents free hours are not exhaustive. This puts in a guard to only do said checks if the actual exaustive eligibility criteria is not passed.