### PR TITLE
DL-19450 - relocate error summary to top of page

### DIFF
--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerMinimumEarnings.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/partnerMinimumEarnings.scala.html
@@ -45,6 +45,8 @@
     pageTitle = title
 ) {
 
+    @errorSummary(form.errors)
+
     @heading(messages("partnerMinimumEarnings.averageWeekly.heading"))
     @p() { @messages("partnerMinimumEarnings.averageWeekly.para1") }
 
@@ -60,8 +62,6 @@
     @p() { @messages("partnerMinimumEarnings.averageWeekly.para4") }<br>
 
     }
-
-    @errorSummary(form.errors)
 
     @formWithCSRF(action = PartnerMinimumEarningsController.onSubmit(), Symbol("autoComplete") -> "off") {
         @inputYesNo(

--- a/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourMinimumEarnings.scala.html
+++ b/app/uk/gov/hmrc/childcarecalculatorfrontend/views/yourMinimumEarnings.scala.html
@@ -45,6 +45,8 @@
     pageTitle = title
 ) {
 
+    @errorSummary(form.errors)
+
     @heading(messages("yourMinimumEarnings.averageWeekly.heading"))
     @p() { @messages("yourMinimumEarnings.averageWeekly.para1") }
 
@@ -59,9 +61,6 @@
     <h2 class="govuk-heading-m">@messages("yourMinimumEarnings.averageWeekly.heading2")</h2>
     @p() { @messages("yourMinimumEarnings.averageWeekly.para3") }
     @p() { @messages("yourMinimumEarnings.averageWeekly.para4") }<br>
-
-
-    @errorSummary(form.errors)
 
     @formWithCSRF(action = YourMinimumEarningsController.onSubmit(), Symbol("autoComplete") -> "off") {
         @inputYesNo(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"         % "2.12.0",
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion" % "13.4.0",
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion" % "13.7.0",
     "uk.gov.hmrc"       %% "tax-year"                         % "6.0.0"
   )
 


### PR DESCRIPTION
Relocates error summary to the top of the page, as described in the Design System: https://design-system.service.gov.uk/components/error-summary/

Before:
<img width="475" height="729" alt="Screenshot 2026-06-08 at 14 11 36" src="https://github.com/user-attachments/assets/8b87f137-e5d3-4149-9455-8d59d539825f" />

After:
<img width="999" height="1471" alt="Screenshot 2026-06-08 at 14 11 58" src="https://github.com/user-attachments/assets/019eae85-0935-49ef-bc03-7f6d275999ea" />
